### PR TITLE
Undocumented routes, align HTTP methods and other boy scoutism

### DIFF
--- a/api-reference/source/includes/_authController.md
+++ b/api-reference/source/includes/_authController.md
@@ -88,14 +88,14 @@ This API route does not require to be logged in.
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "auth",
   "action": "getCurrentUser",
   "requestId": "<unique request identifier>",
   "jwt": "<encrypted_jwt_token>",
   "result": {
-    "_id":"<user id>",
+    "_id":"<userId>",
     "_source": {
       "name": {
         "first": "Steve",
@@ -103,7 +103,7 @@ This API route does not require to be logged in.
         },
         ...                         // The user object content
         "profile": {
-          "_id":"<profile id>",
+          "_id":"<profileId>",
           "roles": [
             ...                     // Users roles definitions
           ]
@@ -225,7 +225,7 @@ Gets the rights of the user identified by the `JSON Web Token` provided in the q
   "requestId": "<unique request identifier>",
   "metadata": {},
   "result": {
-    "_id": "<user ID>",
+    "_id": "<userId>",
     "jwt": "<JWT encrypted token>"
   }
 }
@@ -335,7 +335,7 @@ The **_logout** action doesn't take strategy.
   "metadata": {},
   "requestId": "<unique request identifier>",
   "result": {
-    "_id": "<user id>",
+    "_id": "<userId>",
     "_source": {
       "foo": "bar",
       "name": "Walter Smith",

--- a/api-reference/source/includes/_authController.md
+++ b/api-reference/source/includes/_authController.md
@@ -231,7 +231,7 @@ Gets the rights of the user identified by the `JSON Web Token` provided in the q
 }
 ```
 
-Authenticate a user with a defined **passportjs** authentication strategy.
+Authenticates a user with a defined **passportjs** authentication strategy.
 See [passportjs.org](http://www.passportjs.org/) for more details about authentication strategies.
 
 Strategies are implemented as [plugins](https://github.com/kuzzleio/kuzzle/blob/master/docs/plugins.md).
@@ -265,7 +265,7 @@ The **_login** action returns an encrypted JWT token, that must then be sent wit
 }
 ```
 
-Revoke token validity & unsubscribe from registered rooms
+Revokes the token validity & unsubscribe from registered rooms.
 
 The **_logout** action doesn't take strategy.
 

--- a/api-reference/source/includes/_bulkController.md
+++ b/api-reference/source/includes/_bulkController.md
@@ -21,7 +21,7 @@ even if some of the documents in the import match your subscription filters.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/<data collection>/_bulk`  
+>**URL:** `http://kuzzle:7511/<index>/<collection>/_bulk`  
 >**Method:** `POST`  
 >**Body:**
 
@@ -50,8 +50,8 @@ even if some of the documents in the import match your subscription filters.
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "bulk",
   "action": "import",
 
@@ -69,14 +69,15 @@ even if some of the documents in the import match your subscription filters.
   }
 }
 ```
+
 >Response
 
 ```litcoffee
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "bulk",
   "action": "import",
   "requestId": "<unique request identifier>",
@@ -85,19 +86,19 @@ even if some of the documents in the import match your subscription filters.
     "hits": [
       {
         "create": {
-          "_id": "<document Id>",
+          "_id": "<documentId>",
           "status": <HTTP status code>
         }
       },
       {
         "create": {
-          "_id": "<document ID>",
+          "_id": "<documentId>",
           "status": <HTTP status code>
         }
       },
       {
         "create": {
-          "_id": "<document Id>",
+          "_id": "<documentId>",
           "status": <HTTP status code>
         }
       }
@@ -124,14 +125,14 @@ In such case, the `collection` in which the documents need to be inserted needs 
 {
   // Data mapping using ElasticSearch bulk syntax.
   "bulkData": [
-    {"create": {"_index": "<data index>", "_type": "<data collection>"}},
+    {"create": {"_index": "<index>", "_type": "<collection>"}},
     {"a": "document", "with": "any", "number": "of fields"},
-    {"create": {"_index": "<data index>", "_type": "<data collection>"}},
+    {"create": {"_index": "<index>", "_type": "<collection>"}},
     {"another": "document"},
-    {"create": {"_index": "<data index>", "_type": "<data collection>"}},
+    {"create": {"_index": "<index>", "_type": "<collection>"}},
     {"and": { "another": "one"} },
     ...
-    {"create": {"index": { "_index": "<another data index>", "_type": "<another data collection>" }}}
+    {"create": {"index": { "_index": "<another index>", "_type": "<another collection>" }}}
   ]
 }
 ```
@@ -150,14 +151,14 @@ In such case, the `collection` in which the documents need to be inserted needs 
   "body": {
     // Data mapping using ElasticSearch bulk syntax.
     "bulkData": [
-      {"create": {"_index": "<data index>", "_type": "<data collection>"}},
+      {"create": {"_index": "<index>", "_type": "<collection>"}},
       {"a": "document", "with": "any", "number": "of fields"},
-      {"create": {"_index": "<data index>", "_type": "<data collection>"}},
+      {"create": {"_index": "<index>", "_type": "<collection>"}},
       {"another": "document"},
-      {"create": {"_index": "<data index>", "_type": "<data collection>"}},
+      {"create": {"_index": "<index>", "_type": "<collection>"}},
       {"and": { "another": "one"} },
       ...
-      {"create": {"index": { "_index": "<another data index>", "_type": "<another data collection>" }}}
+      {"create": {"index": { "_index": "<another index>", "_type": "<another collection>" }}}
     ]
   }
 }
@@ -177,19 +178,19 @@ In such case, the `collection` in which the documents need to be inserted needs 
     "hits": [
       {
         "create": {
-          "_id": "<document Id>",
+          "_id": "<documentId>",
           "status": <HTTP status code>
         }
       },
       {
         "create": {
-          "_id": ""<document Id>",
+          "_id": ""<documentId>",
           "status": <HTTP status code>
         }
       },
       {
         "create": {
-          "_id": "<document Id>",
+          "_id": "<documentId>",
           "status": <HTTP status code>
         }
       }

--- a/api-reference/source/includes/_collectionController.md
+++ b/api-reference/source/includes/_collectionController.md
@@ -40,7 +40,7 @@
 }
 ```
 
-When creating a document, Kuzzle will automatically create a data collection if needed.
+When creating a document, Kuzzle will automatically create a collection if needed.
 But in some cases, you may want to create an empty collection directly, prior to storing any document in it.  
 This method does nothing if the collection already exists.
 
@@ -123,7 +123,7 @@ It responds 200 even there where no validation specification manually set before
 }
 ```
 
-Check if a collection exists in Kuzzle database storage layer.
+Checks if a collection exists in Kuzzle database storage layer.
 
 
 ## getMapping
@@ -246,7 +246,8 @@ Gets the mapping of the given `collection`.
 }
 ```
 
-This command allows getting the validation specifications associated to the given index and collection if some specifications has been defined first
+Allows to get the validation specifications associated to the given
+index and collection if some specifications has been defined first.
 
 
 ## getUserMapping
@@ -403,7 +404,7 @@ Gets the mapping of the internal `users` collection.
 }
 ```
 
-Return the complete list of realtime and stored data collections in requested index sorted by name in alphanumerical order.  
+Returns the complete list of realtime and stored data collections in requested index sorted by name in alphanumerical order.  
 The `type` argument filters the returned collections. Allowed values: `all`, `stored` and `realtime` (default : `all`).  
 The `from` and `size` arguments allow pagination. They are returned in the response if provided.
 
@@ -508,7 +509,7 @@ The `from` and `size` arguments allow pagination. They are returned in the respo
 }
 ```
 
-Allow to search in the persistence layer for collection specifications.
+Allows to search in the persistence layer for collection specifications.
 
 
 ## truncate
@@ -550,7 +551,7 @@ Allow to search in the persistence layer for collection specifications.
 }
 ```
 
-This method empties a collection from all its documents, while keeping any associated mapping.  
+Empties a collection from all its documents, while keeping any associated mapping.  
 It is also faster than deleting all documents from a collection using a query.
 
 
@@ -830,7 +831,7 @@ When the validation specification is not well formatted, a detailed error messag
 
 At the first initialization, Kuzzle defines a default mapping for the `users` internal collection in the persistent data storage layer.
 
-This mapping is intended to store the basic informations of a user; typically, its crendentials and rights.
+This mapping is intended to store the basic information of a user; typically, its crendentials and rights.
 
 But if you want to store more information about your users, Kuzzle's API offers a way to update the `users` data mapping using the
 [mapping capabilities of ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/2.3/mapping.html).

--- a/api-reference/source/includes/_collectionController.md
+++ b/api-reference/source/includes/_collectionController.md
@@ -5,7 +5,7 @@
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/<collection name>`  
+>**URL:** `http://kuzzle:7511/<data>/<collection>`  
 >**Method:** `PUT`
 
 <section class="others"></section>
@@ -16,8 +16,8 @@
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<collection name>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "collection",
   "action": "create"
 }
@@ -29,8 +29,8 @@
 {
   "status": 200,
   "error": null,
-  "index": "<data index>",
-  "collection": "<collection name>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "collection",
   "action": "create",
   "requestId": "<unique request identifier>",
@@ -49,7 +49,7 @@ This method does nothing if the collection already exists.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/<data collection>/_specifications`  
+>**URL:** `http://kuzzle:7511/<index>/<collection>/_specifications`  
 >**Method:** `DELETE`
 
 <section class="others"></section>
@@ -59,10 +59,10 @@ This method does nothing if the collection already exists.
 <section class="others"></section>
 ```litcoffee
 {
-  index: "<data index>",
-  collection: "<data collection>",
-  controller: "collection",
-  action: "deleteSpecifications",
+  "index": "<index>",
+  "collection": "<collection>",
+  "controller": "collection",
+  "action": "deleteSpecifications",
 }
 ```
 
@@ -70,17 +70,17 @@ This method does nothing if the collection already exists.
 
 ```litcoffee
 {
-  status: 200,                      // Assuming everything went well
-  error: null,                      // Assuming everything went well
-  index: "<data index>",
-  collection: "<data collection>",
-  action: "deleteSpecifications",
-  controller: "collection",
-  result: {}
+  "status": 200,                      // Assuming everything went well
+  "error": null,                      // Assuming everything went well
+  "index": "<index>",
+  "collection": "<collection>",
+  "action": "deleteSpecifications",
+  "controller": "collection",
+  "result": {}
 }
 ```
 
-Deletes the validation specification set for the <data index>/<data collection>.
+Deletes the validation specification set for the <index>/<collection>.
 It responds 200 even there where no validation specification manually set before.
 
 ***Note:*** by default, an empty specification is implicitally applied to all collections which. In a way, "no specification set" means "all documents are valid". This is why, using this route when no specifications have been set before, does not produce an error.
@@ -90,7 +90,7 @@ It responds 200 even there where no validation specification manually set before
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/<data collection>/_exists`  
+>**URL:** `http://kuzzle:7511/<index>/<collection>/_exists`  
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -101,8 +101,8 @@ It responds 200 even there where no validation specification manually set before
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "collection",
   "action": "exists"
 }
@@ -114,8 +114,8 @@ It responds 200 even there where no validation specification manually set before
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "exists",
   "action": "exists",
   "requestId": "<unique request identifier>",
@@ -130,7 +130,7 @@ Check if a collection exists in Kuzzle database storage layer.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/<data collection>/_mapping`  
+>**URL:** `http://kuzzle:7511/<index>/<collection>/_mapping`  
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -141,8 +141,8 @@ Check if a collection exists in Kuzzle database storage layer.
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "collection",
   "action": "getMapping"
 }
@@ -154,22 +154,22 @@ Check if a collection exists in Kuzzle database storage layer.
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "collection",
   "action": "getMapping",
   "requestId": "<unique request identifier>",
   "result": {
     "mainindex": {
       "mappings": {
-        <data collection>: {
+        <collection>: {
 
           // Data mapping using ElasticSearch mapping syntax
           "properties": {
-            "field1": {type: "field type", ...options... },
-            "field2": {type: "field type", ...options... },
+            "field1": {type: "field type", "...options..." },
+            "field2": {type: "field type", "...options..." },
             ...
-            "fieldn": {type: "field type", ...options... },
+            "fieldn": {type: "field type", "...options..." },
           }
         }
       }
@@ -185,7 +185,7 @@ Gets the mapping of the given `collection`.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/<data collection>/_specifications`  
+>**URL:** `http://kuzzle:7511/<index>/<collection>/_specifications`  
 >**Method:** `GET`  
 
 <section class="others"></section>
@@ -196,10 +196,10 @@ Gets the mapping of the given `collection`.
 
 ```litcoffee
 {
-  index: "<data index>",
-  collection: "<data collection>",
-  controller: "collection",
-  action: "getSpecifications",
+  "index": "<index>",
+  "collection": "<collection>",
+  "controller": "collection",
+  "action": "getSpecifications",
 }
 ```
 
@@ -207,53 +207,53 @@ Gets the mapping of the given `collection`.
 
 ```litcoffee
 {
-  status: 200,                      // Assuming everything went well
-  error: null,                      // Assuming everything went well
-  action: "getSpecifications",
-  controller: "collection",
-  collection: "<data collection>",
-  index: "<data index>",
-  result: {
-    collection: "<data collection>",
-    index: "<data index>",
-    validation": {
-      fields: {
-        myField: {
-          defaultValue: 42,
-          mandatory: true,
-          type: "integer"
+  "status": 200,                      // Assuming everything went well
+  "error": null,                      // Assuming everything went well
+  "action": "getSpecifications",
+  "controller": "collection",
+  "collection": "<collection>",
+  "index": "<index>",
+  "result": {
+    "collection": "<collection>",
+    "index": "<index>",
+    "validation": {
+      "fields": {
+        myField": {
+          "defaultValue": 42,
+          "mandatory": true,
+          "type": "integer"
         }
         ...
       },
-      strict: true
+      "strict": true
     }
   }
 }
 
 {
-  status: 404,                      // No validation specification has been set for this index/collection
-  error: {
-    _source: {
-      body: {}
+  "status": 404,                      // No validation specification has been set for this index/collection
+  "error": {
+    "_source": {
+      "body": {}
     },
-    message: "Not Found"
+    "message": "Not Found"
   },
-  action: "getSpecifications",
-  controller: "collection",
-  index: "<data index>",
-  collection: "<data collection>"
-  result: null
+  "action": "getSpecifications",
+  "controller": "collection",
+  "index": "<index>",
+  "collection": "<collection>"
+  "result": null
 }
 ```
 
 This command allows getting the validation specifications associated to the given index and collection if some specifications has been defined first
 
 
-## list
+## getUserMapping
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/_list(/<all|stored|realtime>)[?from=0][&size=42]`  
+>**URL:** `http://kuzzle:7511/users/_mapping`  
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -264,7 +264,94 @@ This command allows getting the validation specifications associated to the give
 
 ```litcoffee
 {
-  "index": "<data index>",
+  "controller": "collection",
+  "action": "getUserMapping"
+}
+```
+
+>Response
+
+```litcoffee
+{
+  "status": 200,                      // Assuming everything went well
+  "error": null,                      // Assuming everything went well
+  "controller": "collection",
+  "action": "getUserMapping",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "mapping": {
+      "hobby": {
+        "fields": {
+          "keyword": {
+            "ignore_above": 256,
+            "type": "keyword"
+          }
+        },
+        "type": "text"
+      },
+      "name": {
+        "properties": {
+          "first": {
+            "fields": {
+              "keyword": {
+                "ignore_above": 256,
+                "type": "keyword"
+              }
+            },
+            "type": "text"
+          },
+          "last": {
+            "fields": {
+              "keyword": {
+                "ignore_above": 256,
+                "type": "keyword"
+              }
+            },
+            "type": "text"
+          },
+          "real": {
+            "fields": {
+              "keyword": {
+                "ignore_above": 256,
+                "type": "keyword"
+              }
+            },
+            "type": "text"
+          }
+        }
+      },
+      "password": {
+        "index": false,
+        "type": "keyword"
+      },
+      "profileIds": {
+        "type": "keyword"
+      }
+    }
+  }
+}
+```
+
+Gets the mapping of the internal `users` collection.
+
+
+
+## list
+
+<section class="http"></section>
+
+>**URL:** `http://kuzzle:7511/<index>/_list(/<all|stored|realtime>)[?from=0][&size=42]`  
+>**Method:** `GET`
+
+<section class="others"></section>
+
+>Query
+
+<section class="others"></section>
+
+```litcoffee
+{
+  "index": "<index>",
   "controller": "collection",
   "action": "list",
   "type": "<all|stored|realtime>",
@@ -280,38 +367,35 @@ This command allows getting the validation specifications associated to the give
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
+  "index": "<index>",
   "controller": "collection",
   "action": "list",
   "requestId": "<unique request identifier>",
   "result": {
     "collections": [
       {
-        "name": "realtime_1",
-        "type": "realtime"
+        "name": "realtime_1", "type": "realtime"
       },
       {
-        "name": "realtime_2",
-        "type": "realtime"
+        "name": "realtime_2", "type": "realtime"
       },
       {
-        "name": "realtime_...",
-        "type": "realtime"
+        "name": "realtime_...", "type": "realtime"
       },
       {
-        "name": "realtime_n", type: "realtime"
+        "name": "realtime_n", "type": "realtime"
       },
       {
-        "name": "stored_1", type: "stored"
+        "name": "stored_1", "type": "stored"
       },
       {
-        "name": "stored_2", type: "stored"
+        "name": "stored_2", "type": "stored"
       },
       {
-        "name": "stored_...", type: "stored"
+        "name": "stored_...", "type": "stored"
       },
       {
-        "name": "stored_n", type: "stored"
+        "name": "stored_n", "type": "stored"
       }
     ],
     "type": "all"
@@ -324,11 +408,114 @@ The `type` argument filters the returned collections. Allowed values: `all`, `st
 The `from` and `size` arguments allow pagination. They are returned in the response if provided.
 
 
+## searchSpecifications
+
+
+<section class="http"></section>
+
+>**URL:** `http://kuzzle:7511/_searchSpecifications`  
+>**Method:** `POST`  
+>**Body**
+
+<section class="http"></section>
+
+```litcoffee
+{
+  // A set of filters or queries matching documents you are looking for.
+  "query": {
+    ...
+  }
+}
+```
+
+<section class="others"></section>
+
+>Query
+
+<section class="others"></section>
+
+```litcoffee
+{
+  "controller": "collection",
+  "action": "searchSpecifications",
+  "body": {
+    // A set of filters or queries matching documents you are looking for.
+    "query": {
+      "Some": "filters"
+    }
+  },
+  // "from" and "size" argument for pagination
+  "from": 0,
+  "size": 42
+}
+```
+```
+
+>Response
+
+```litcoffee
+{
+  "status": 200,                      // Assuming everything went well
+  "error": null,                      // Assuming everything went well
+  "controller": "collection",
+  "action": "searchSpecifications",
+  "metadata": {},
+  "requestId": "<unique request identifier>",
+  "result": {
+    "_shards": {
+        "failed": 0,
+        "successful": 5,
+        "total": 5
+    },
+    "hits": [
+      {
+        "_id": "myIndex#myCollection", 
+        "_index": "%kuzzle", 
+        "_score": 1, 
+        "_source": {
+          "collection": "myCollection", 
+          "index": "myIndex", 
+          "validation": {
+            "fields": {
+              "fieldName": {
+                "defaultValue": "a default value", 
+                "mandatory": true, 
+                "multivalued": {
+                  "maxCount": 5, 
+                  "minCount": 1, 
+                  "value": true
+                }, 
+                "type": "string", 
+                "typeOptions": {
+                  "length": {
+                    "max": 12, 
+                    "min": 2
+                  }
+                }
+              }
+            }, 
+            "strict": true
+          }
+        }, 
+        "_type": "validations"
+      }
+    ],
+    "max_score": null,
+    "timed_out": false,
+    "took": 1,
+    "total": <number of results>
+  }
+}
+```
+
+Allow to search in the persistence layer for collection specifications.
+
+
 ## truncate
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/<collection name>/_truncate`  
+>**URL:** `http://kuzzle:7511/<index>/<collection>/_truncate`  
 >**Method:** `DELETE`
 
 <section class="others"></section>
@@ -339,8 +526,8 @@ The `from` and `size` arguments allow pagination. They are returned in the respo
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "collection",
   "action": "truncate"
 }
@@ -354,8 +541,8 @@ The `from` and `size` arguments allow pagination. They are returned in the respo
   "error": null,
   "action": "truncate",
   "controller": "collection",
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "requestId": "<unique request identifier>",
   "result": {
     "acknowledged": true,
@@ -371,7 +558,7 @@ It is also faster than deleting all documents from a collection using a query.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/<data collection>/_mapping`  
+>**URL:** `http://kuzzle:7511/<index>/<collection>/_mapping`  
 >**Method:** `PUT`  
 >**Body:**
 
@@ -383,16 +570,16 @@ It is also faster than deleting all documents from a collection using a query.
   "properties": {
     "field1": {
       "type": "field type",
-      "...options..."
+      "other": "...options..."
     },
     "field2": {
       "type": "field type",
-      "...options..."
+      "other": "...options..."
     },
     ...
     "fieldn": {
       "type": "field type",
-      "...options..."
+      "other": "...options..."
     }
   }
 }
@@ -406,8 +593,8 @@ It is also faster than deleting all documents from a collection using a query.
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "collection",
   "action": "updateMapping",
 
@@ -438,8 +625,8 @@ It is also faster than deleting all documents from a collection using a query.
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "action": "updateMapping",
   "controller": "collection",
   "requestId": "<unique request identifier>",
@@ -470,10 +657,10 @@ To solve this matter, Kuzzle's API offers a way to create data mapping and to ex
 
 ```litcoffee
 {
-  myindex: {
-    mycollection: {
-      strict: <true|false>,
-      fields: {
+  "myindex": {
+    "mycollection": {
+      "strict": <true|false>,
+      "fields": {
         // ... specification for each field
       }
     }
@@ -489,15 +676,15 @@ To solve this matter, Kuzzle's API offers a way to create data mapping and to ex
 
 ```litcoffee
 {
-  controller: "collection",
-  action: "updateSpecifications",
+  "controller": "collection",
+  "action": "updateSpecifications",
 
   // Data mapping using ElasticSearch mapping syntax
-  body: {
-    myindex: {
-      mycollection: {
-        strict: <true|false>,
-        fields: {
+  "body": {
+    "myindex": {
+      "mycollection": {
+        "strict": <true|false>,
+        "fields": {
           // ... specification for each field
         }
       }
@@ -511,17 +698,17 @@ To solve this matter, Kuzzle's API offers a way to create data mapping and to ex
 
 ```litcoffee
 {
-  status: 200,                      // Assuming everything went well
-  error: null,                      // Assuming everything went well
-  index: "<data index>",
-  collection: "<data collection>",
-  action: "updateSpecifications",
-  controller: "collection",
-  result: {
-    myindex: {
-      mycollection: {
-        strict: <true|false>,
-        fields: {
+  "status": 200,                      // Assuming everything went well
+  "error": null,                      // Assuming everything went well
+  "index": "<index>",
+  "collection": "<collection>",
+  "action": "updateSpecifications",
+  "controller": "collection",
+  "result": {
+    "myindex": {
+      "mycollection": {
+        "strict": <true|false>,
+        "fields": {
           // ... specification for each field
         }
       }
@@ -530,24 +717,24 @@ To solve this matter, Kuzzle's API offers a way to create data mapping and to ex
 }
 
 {
-  status: 400,                      // There was an error on specification
-  action: "updateSpecifications",
-  controller: "collections",
-  error: {
-    _source: // ... given specifications,
-    message: {
-      description: // ...global error description,
-      details: // ... an array of detailed problem found,
-      valid: false // the specifications are not valid
+  "status": 400,                      // There was an error on specification
+  "action": "updateSpecifications",
+  "controller": "collections",
+  "error": {
+    "_source": // ... given specifications,
+    "message": {
+      "description": // ...global error description,
+      "details": // ... an array of detailed problem found,
+      "valid": false // the specifications are not valid
     }
   },
-  metadata: {},
-  result: {
-    myindex: {
-      mycollection: {
-        strict: <true|false>,
-        fields: {
-          myField: {
+  "metadata": {},
+  "result": {
+    "myindex": {
+      "mycollection": {
+        "strict": <true|false>,
+        "fields": {
+          "myField": {
              // ... specification with an error
           }
         }
@@ -563,6 +750,92 @@ This method allows you to specify or update the validation specifications. You c
 When the validation specification is not well formatted, a detailed error message is answered by Kuzzle to help you to debug.
 
 
+## updateUserMapping
+
+<section class="http"></section>
+
+>**URL:** `http://kuzzle:7511/users/_mapping`  
+>**Method:** `PUT`  
+>**Body:**
+
+<section class="http"></section>
+
+```litcoffee
+{
+  // Data mapping using ElasticSearch mapping syntax
+  "properties": {
+    "field1": {
+      "type": "field type",
+      "other": "...options..."
+    },
+    "field2": {
+      "type": "field type",
+      "other": "...options..."
+    },
+    ...
+    "fieldn": {
+      "type": "field type",
+      "other": "...options..."
+    }
+  }
+}
+```
+
+<section class="others"></section>
+
+>Query
+
+<section class="others"></section>
+
+```litcoffee
+{
+  "controller": "collection",
+  "action": "updateUserMapping",
+
+  // Data mapping using ElasticSearch mapping syntax
+  "body": {
+    "properties": {
+      "field1": {
+        "type": "field type",
+        "other": "...options..."
+      },
+      "field2": {
+        "type": "field type",
+        "other": "...options..."
+      },
+      ...
+      "fieldn": {
+        "type": "field type",
+        "other": "...options..."
+      }
+    }
+  }
+}
+```
+
+>Response
+
+```litcoffee
+{
+  "status": 200,                      // Assuming everything went well
+  "error": null,                      // Assuming everything went well
+  "action": "updateMapping",
+  "controller": "collection",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "acknowledged": true
+  },
+}
+```
+
+At the first initialization, Kuzzle defines a default mapping for the `users` internal collection in the persistent data storage layer.
+
+This mapping is intended to store the basic informations of a user; typically, its crendentials and rights.
+
+But if you want to store more information about your users, Kuzzle's API offers a way to update the `users` data mapping using the
+[mapping capabilities of ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/2.3/mapping.html).
+
+
 ## validateSpecifications
 
 <section class="http"></section>
@@ -575,10 +848,10 @@ When the validation specification is not well formatted, a detailed error messag
 
 ```litcoffee
 {
-  myindex: {
-    mycollection: {
-      strict: <true|false>,
-      fields: {
+  "myindex": {
+    "mycollection": {
+      "strict": <true|false>,
+      "fields": {
         // ... specification for each field
       }
     }
@@ -594,15 +867,15 @@ When the validation specification is not well formatted, a detailed error messag
 
 ```litcoffee
 {
-  controller: "admin",
-  action: "updateSpecifications",
+  "controller": "admin",
+  "action": "updateSpecifications",
 
   // Data mapping using ElasticSearch mapping syntax
-  body: {
-    myindex: {
-      mycollection: {
-        strict: <true|false>,
-        fields: {
+  "body": {
+    "myindex": {
+      "mycollection": {
+        "strict": <true|false>,
+        "fields": {
           // ... specification for each field
         }
       }
@@ -616,20 +889,20 @@ When the validation specification is not well formatted, a detailed error messag
 
 ```litcoffee
 {
-  status: 200,                      // Assuming everything went well
-  error: null,                      // Assuming everything went well
-  index: "<data index>",
-  collection: "<data collection>",
-  action: "updateMapping",
-  controller: "admin",
-  state: "done",
-  requestId, "<unique request identifier>",
-  result: {
-    valid: <true|false>,
-    details: [ // it some errors have been found
+  "status": 200,                      // Assuming everything went well
+  "error": null,                      // Assuming everything went well
+  "index": "<index>",
+  "collection": "<collection>",
+  "action": "updateMapping",
+  "controller": "admin",
+  "state": "done",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "valid": <true|false>,
+    "details": [ // it some errors have been found
       // each spotted errors
     ],
-    description: <string> // global description if validation fails
+    "description": "<string>" // global description if validation fails
   }
 }
 ```

--- a/api-reference/source/includes/_collectionController.md
+++ b/api-reference/source/includes/_collectionController.md
@@ -116,7 +116,7 @@ It responds 200 even there where no validation specification manually set before
   "error": null,                      // Assuming everything went well
   "index": "<index>",
   "collection": "<collection>",
-  "controller": "exists",
+  "controller": "collection",
   "action": "exists",
   "requestId": "<unique request identifier>",
   "result": true

--- a/api-reference/source/includes/_documentController.md
+++ b/api-reference/source/includes/_documentController.md
@@ -5,7 +5,7 @@
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/<data collection>/_count`  
+>**URL:** `http://kuzzle:7511/<index>/<collection>/_count`  
 >**Method:** `POST`  
 >**Body:**
 
@@ -29,8 +29,8 @@
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "count",
 
@@ -50,8 +50,8 @@
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "count",
   "requestId": "<unique request identifier>",
@@ -70,7 +70,7 @@ Kuzzle uses the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasti
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/<data collection>/_create[?refresh=wait_for]`  
+>**URL:** `http://kuzzle:7511/<index>/<collection>/_create[?refresh=wait_for]` or `http://kuzzle:7511/<index>/<collection>/<documentId>/_create[?refresh=wait_for]`  
 >**Method:** `POST`  
 >**Body:**
 
@@ -90,11 +90,12 @@ Kuzzle uses the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasti
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "create",
   ["refresh": "wait_for",]
+  "_id": "<documentId>",              // Optional. If not provided, will be generated automatically.
   "body": {
     // the document to create
   }
@@ -107,13 +108,13 @@ Kuzzle uses the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasti
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "create",
   "requestId": "<unique request identifier>",
   "result": {
-    "_id": "<Unique document ID>",    // The generated document ID
+    "_id": "<documentId>",            // The generated or provided document id
     "_version": 1                     // The version of the document in the persistent data storage
     "_source": {                      // The created document
       ...
@@ -134,8 +135,7 @@ with the value `wait_for` in order to wait for the document indexation (availabi
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/<data collection>/<documentId>[?refresh=wait_for]`
-or `http://kuzzle:7511/<data index>/<data collection>/<documentId>/_createOrReplace[?refresh=wait_for]`  
+>**URL:** `http://kuzzle:7511/<index>/<collection>/<documentId>[?refresh=wait_for]`  
 >**Method:** `PUT`  
 >**Body:**
 
@@ -155,11 +155,12 @@ or `http://kuzzle:7511/<data index>/<data collection>/<documentId>/_createOrRepl
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "createOrReplace",
   ["refresh": "wait_for",]
+  "_id": "<documentId>",            // Mandatory: The document id.
   // The document itself
   "body": {
     ...
@@ -173,13 +174,13 @@ or `http://kuzzle:7511/<data index>/<data collection>/<documentId>/_createOrRepl
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "createOrReplace",
   "requestId": "<unique request identifier>",
   "result": {
-    "_id": "<Unique document ID>",    // The generated document ID
+    "_id": "<documentId>",
     "_source": {                      // The created document
       ...
     },
@@ -199,7 +200,7 @@ with the value `wait_for` in order to wait for the document indexation (availabi
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/<data collection>/<documentID>[?refresh=wait_for]`  
+>**URL:** `http://kuzzle:7511/<index>/<collection>/<documentId>[?refresh=wait_for]`  
 >**Method:** `DELETE`
 
 <section class="others"></section>
@@ -210,15 +211,15 @@ with the value `wait_for` in order to wait for the document indexation (availabi
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "delete",
   ["refresh": "wait_for",]
 
-  // The document unique identifier. It's the same one that Kuzzle sends you
-  // in its responses when you create a document, or when you do a search query.
-  "_id": "<document ID>"
+  // The document id you provided or that was generated at document creation.
+  // it is also the one returned during a search query.
+  "_id": "<documentId>"
 }
 ```
 
@@ -228,13 +229,13 @@ with the value `wait_for` in order to wait for the document indexation (availabi
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "delete",
   "requestId": "<unique request identifier>",
   "result": {
-    "_id": "<document ID>"            // The deleted document identifier
+    "_id": "<documentId>"             // The deleted document identifier
   }
 }
 ```
@@ -251,7 +252,7 @@ with the value `wait_for` in order to wait for the document deletion (and its un
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/<data collection>/_query`  
+>**URL:** `http://kuzzle:7511/<index>/<collection>/_query`  
 >**Method:** `DELETE`  
 >**Body:**
 
@@ -275,8 +276,8 @@ with the value `wait_for` in order to wait for the document deletion (and its un
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "deleteByQuery",
 
@@ -296,8 +297,8 @@ with the value `wait_for` in order to wait for the document deletion (and its un
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "deleteByQuery",
   "requestId": "<unique request identifier>",
@@ -317,7 +318,7 @@ Kuzzle uses the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasti
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/<data collection>/<document Id>`  
+>**URL:** `http://kuzzle:7511/<index>/<collection>/<documentId>`  
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -328,14 +329,14 @@ Kuzzle uses the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasti
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "get",
 
-  // The document unique identifier. It's the same one that Kuzzle sends you
-  // in its responses when you create a document, or when you do a search query.
-  "_id": "<document ID>"
+  // The document id you provided or that was generated at document creation.
+  // it is also the one returned during a search query.
+  "_id": "<documentId>"
 }
 ```
 
@@ -345,15 +346,15 @@ Kuzzle uses the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasti
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "get",
   "requestId": "<unique request identifier>",
   "result": {
-    "_id": "<Unique document ID>",    // The generated document ID
-    "_index": "<data index>",
-    "_type": "<data collection>",
+    "_id": "<documentId>",
+    "_index": "<index>",
+    "_type": "<collection>",
     "_version": 1,
     "_source": {
       "name": {
@@ -376,7 +377,7 @@ Only documents in the persistent data storage layer can be retrieved.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/<data collection>/<documentId>/_replace[?refresh=wait_for]`  
+>**URL:** `http://kuzzle:7511/<index>/<collection>/<documentId>/_replace[?refresh=wait_for]`  
 >**Method:** `PUT`  
 >**Body:**
 
@@ -396,8 +397,8 @@ Only documents in the persistent data storage layer can be retrieved.
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "replace",
   ["refresh": "wait_for",]
@@ -414,13 +415,13 @@ Only documents in the persistent data storage layer can be retrieved.
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "replace",
   "requestId": "<unique request identifier>",
   "result": {
-    "_id": "<Unique document ID>",    // The document unique ID
+    "_id": "<documentId>",
     "_source": {                      // The resulting document
       ...
     },
@@ -490,7 +491,7 @@ with the value `wait_for` in order to wait for the document indexation (availabi
     // An array of objects containing your retrieved documents
     "hits": [
       {
-        "_id": "<document unique ID>",
+        "_id": "documentId",
         "_score": "<document score>"
         "_source": { .. }         // The actual document
       },
@@ -526,7 +527,7 @@ which tells Elasticsearch how long it should keep the “search context” alive
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/<data collection>/_search[?from=0][&size=42]`  
+>**URL:** `http://kuzzle:7511/<index>/<collection>/_search[?from=0][&size=42]`  
 >**Method:** `POST`  
 >**Body:**
 
@@ -535,8 +536,7 @@ which tells Elasticsearch how long it should keep the “search context” alive
 ```litcoffee
 {
   // A set of filters or queries matching documents you are looking for.
-  // Use "query" instead of "filter" if you want to perform a query instead.
-  "filter": {
+  "query": {
     ...
   },
   "aggregations": {
@@ -553,15 +553,14 @@ which tells Elasticsearch how long it should keep the “search context” alive
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "search",
 
   "body": {
     // A set of filters or queries matching documents you are looking for.
-    // Use "query" instead of "filter" if you want to perform a query instead.
-    "filter": {
+    "query": {
 
     },
     "aggregations": {
@@ -580,8 +579,8 @@ which tells Elasticsearch how long it should keep the “search context” alive
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "action": "search",
   "controller": "document",
   "requestId": "<unique request identifier>",
@@ -593,7 +592,7 @@ which tells Elasticsearch how long it should keep the “search context” alive
     // An array of objects containing your retrieved documents
     "hits": [
       {
-        "_id": "<document unique ID>",
+        "_id": "documentId",
         "_score": "<document score>"
         "_source": { ... }         // The actual document
       },
@@ -627,7 +626,7 @@ for more details.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/<data collection>/<documentId>/_update[?refresh=wait_for]`  
+>**URL:** `http://kuzzle:7511/<index>/<collection>/<documentId>/_update[?refresh=wait_for]`  
 >**Method:** `PUT`  
 >**Body:**
 
@@ -649,14 +648,14 @@ for more details.
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "update",
   ["refresh": "wait_for",]
-  // The document unique identifier. It's the same one that Kuzzle sends you
-  // in its responses when you create a document, or when you do a search query.
-  "_id": "<document ID>"
+  // The document id you provided or that was generated at document creation.
+  // it is also the one returned during a search query.
+  "_id": "<documentId>"
 
   // The actual update query
   "body": {
@@ -673,13 +672,18 @@ for more details.
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "update",
   "requestId": "<unique request identifier>",
   "result": {
-    "_id":
+    "_id": "<documentId>",
+    "_source": {                      // The resulting document
+      ...
+    },
+    "_version": <number>,             // The new version number of this document
+    "created": false
   }
 }
 ```
@@ -694,7 +698,7 @@ with the value `wait_for` in order to wait for the document indexation (availabi
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/<data collection>/_validate`  
+>**URL:** `http://kuzzle:7511/<index>/<collection>/_validate`  
 >**Method:** `POST`  
 >**Body:**
 
@@ -714,8 +718,8 @@ with the value `wait_for` in order to wait for the document indexation (availabi
 
 ```litcoffee
 {
-  index: "<data index>",
-  collection: "<data collection>",
+  index: "<index>",
+  collection: "<collection>",
   controller: "document",
   action: "validate",
   // The document itself
@@ -731,8 +735,8 @@ with the value `wait_for` in order to wait for the document indexation (availabi
 {
   status: 200,                      // Assuming everything went well
   error: null,                      // Assuming everything went well
-  index: "<data index>",
-  collection: "<data collection>",
+  index: "<index>",
+  collection: "<collection>",
   controller: "document",
   action: "validate",
   metadata: {},

--- a/api-reference/source/includes/_documentController.md
+++ b/api-reference/source/includes/_documentController.md
@@ -368,7 +368,7 @@ Kuzzle uses the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasti
 }
 ```
 
-Given a `document id`, retrieve the corresponding document from the database.
+Given a `document id`, retrieves the corresponding document from the database.
 
 Only documents in the persistent data storage layer can be retrieved.
 
@@ -747,7 +747,7 @@ with the value `wait_for` in order to wait for the document indexation (availabi
 }
 ```
 
-Validate data against existing validation rules. The data is not published nor stored by Kuzzle
+Validates data against existing validation rules. The data is not published nor stored by Kuzzle
 If the document complies, the `result.valid` value is `true`, if not, it is `false`.
 When the document does not complies, both `result.errorMessages` contains some very detailed hints on what is wrong with the document.
 Note that if no validation specifications are set for the &lt;data index>/&lt;data collection>, the document always validate.

--- a/api-reference/source/includes/_indexController.md
+++ b/api-reference/source/includes/_indexController.md
@@ -119,7 +119,7 @@ Deletes an entire `index` from Kuzzle's persistent storage layer.
 }
 ```
 
-Check if the given index exists in Kuzzle storage layer.
+Checks if the given index exists in Kuzzle storage layer.
 
 
 ## getAutoRefresh
@@ -215,7 +215,7 @@ The `getAutoRefresh` actions returns the current `autoRefresh` status for the gi
 }
 ```
 
-Return the complete data indexes.
+Returns the complete data indexes.
 
 
 ## mDelete

--- a/api-reference/source/includes/_indexController.md
+++ b/api-reference/source/includes/_indexController.md
@@ -5,8 +5,8 @@
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>`  
->**Method:** `PUT`
+>**URL:** `http://kuzzle:7511/<index>`  
+>**Method:** `POST`
 
 <section class="others"></section>
 
@@ -16,7 +16,7 @@
 
 ```litcoffee
 {
-  "index": "<data index>",
+  "index": "<index>",
   "controller": "index",
   "action": "create"
 }
@@ -28,7 +28,7 @@
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
+  "index": "<index>",
   "action": "create",
   "controller": "index",
   "requestId": "<unique request identifier>",
@@ -48,7 +48,7 @@ Create an `index` in Kuzzle's persistent storage layer.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>`  
+>**URL:** `http://kuzzle:7511/<index>`  
 >**Method:** `DELETE`
 
 <section class="others"></section>
@@ -59,7 +59,7 @@ Create an `index` in Kuzzle's persistent storage layer.
 
 ```litcoffee
 {
-  "index": "<data index>",
+  "index": "<index>",
   "controller": "index",
   "action": "delete"
 }
@@ -71,7 +71,7 @@ Create an `index` in Kuzzle's persistent storage layer.
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
+  "index": "<index>",
   "controller": "index",
   "action": "delete",
   "requestId": "<unique request identifier>",
@@ -88,7 +88,7 @@ Deletes an entire `index` from Kuzzle's persistent storage layer.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/_exists`  
+>**URL:** `http://kuzzle:7511/<index>/_exists`  
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -99,7 +99,7 @@ Deletes an entire `index` from Kuzzle's persistent storage layer.
 
 ```litcoffee
 {
-  "index": "<data index>",
+  "index": "<index>",
   "controller": "index",
   "action": "exists"
 }
@@ -111,7 +111,7 @@ Deletes an entire `index` from Kuzzle's persistent storage layer.
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
+  "index": "<index>",
   "controller": "index",
   "action": "exists",
   "requestId": "<unique request identifier>",
@@ -312,9 +312,9 @@ The response contains the list of indexes that were actually deleted.
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
+  "index": "<index>",
   "controller": "index",
-  "action": "delete",
+  "action": "refresh",
   "requestId": "<unique request identifier>",
   "result": {
     "_shards": {
@@ -333,6 +333,66 @@ By default, this operation can take up to 1 second.
 Given an index, the `refresh` action forces a
 [`refresh`](https://www.elastic.co/guide/en/elasticsearch/guide/current/near-real-time.html#refresh-api),
 on it, making the documents visible to search immediately.
+
+<aside class="left warning">
+  <p>
+    A refresh operation comes with some performance costs.<br>
+  </p>
+  <p>
+    From <a href="https://www.elastic.co/guide/en/elasticsearch/guide/current/near-real-time.html#refresh-api">
+    Elasticsearch documentation</a>:
+    <div class="quote">
+      "While a refresh is much lighter than a commit, it still has a performance cost.
+      A manual refresh can be useful when writing tests, but don’t do a manual refresh every time
+      you index a document in production; it will hurt your performance. Instead, your application
+      needs to be aware of the near real-time nature of Elasticsearch and make allowances for it."
+    </div>
+  </p>
+</aside>
+
+
+## refreshInternal
+
+<section class="http"></section>
+
+>**URL:** `http://kuzzle:7511/_refreshInternal`  
+>**Method:** `POST`
+
+<section class="others"></section>
+
+>Query
+
+<section class="others"></section>
+
+```litcoffee
+{
+  "controller": "index",
+  "action": "refreshInternal"
+}
+```
+
+>Response
+
+```litcoffee
+{
+  "status": 200,                      // Assuming everything went well
+  "error": null,                      // Assuming everything went well
+  "controller": "index",
+  "action": "refreshInternal",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "acknowledged": true
+  }
+}
+```
+
+When writing or deleting security and internal documents (users, roles, profiles, configuration, etc.)
+in Kuzzle's database layer, the update needs to be indexed before being reflected in the search index.
+By default, this operation can take up to 1 second.
+
+Given an index, the `refreshInternal` action forces a
+[`refresh`](https://www.elastic.co/guide/en/elasticsearch/guide/current/near-real-time.html#refresh-api),
+on the internal index, making the documents visible to search immediately.
 
 <aside class="left warning">
   <p>

--- a/api-reference/source/includes/_kuzzleResponse.md
+++ b/api-reference/source/includes/_kuzzleResponse.md
@@ -9,12 +9,12 @@
   "error": {...},
 
   // Some information about the initial request
-  "index": "<data index>",
+  "index": "<index>",
   "collection": "<collection>",
   "controller": "<controller>",
   "action": "<action>",
 
-  // Completion state of the request.
+  // For notification only, completion state of the request.
   // A pending request will receive a "done" notification once it is processed by Kuzzle.
   "state": "<done|pending>",
 
@@ -25,7 +25,7 @@
   "metadata": { foo: "bar" },
 
   // Your query unique identifier.
-  "requestId": "<unique ID>",
+  "requestId": "<unique request identifier>",
 
   // Complex object, depending on your query
   "result": {

--- a/api-reference/source/includes/_notifications.md
+++ b/api-reference/source/includes/_notifications.md
@@ -228,8 +228,8 @@ You can receive the following types of notifications:
 {
   "status": 200,                        // Assuming everything went well
   "error": null,                        // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "create",
   "state": "done",                      // The document has been fully created
@@ -238,9 +238,9 @@ You can receive the following types of notifications:
     // metadata embedded in the request
   },
   "requestId": "<unique request identifier>",
-  "result": {
-    "_id": "unique document ID",
-    "_source": {...}                    // The created document
+  "result": {                           // The created document
+    "_id": "documentId",
+    "_source": {...}
   }
 }
 ```
@@ -254,8 +254,8 @@ You can receive the following types of notifications:
 {
   "status": 200,                        // Assuming everything went well
   "error": null,                        // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "update",
   "state": "done",                      // The document has been fully updated
@@ -265,7 +265,7 @@ You can receive the following types of notifications:
   },
   "requestId": "<unique request identifier>",
   "result": {                           // The updated document
-    "_id": "<unique document ID>",
+    "_id": "<documentId>",
     ...
   }
 }
@@ -280,8 +280,8 @@ You can receive the following types of notifications:
 {
   "status": 200,                        // Assuming everything went well
   "error": null,                        // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "update",
   "state": "done",                     // The document has been fully updated
@@ -291,7 +291,7 @@ You can receive the following types of notifications:
   },
   "requestId": "<unique request identifier>",
   "result": {                          // The updated document
-    "_id": "<unique document ID>",
+    "_id": "<documentId>",
     ...
   }
 }
@@ -306,8 +306,8 @@ You can receive the following types of notifications:
 {
   "status": 200,                        // Assuming everything went well
   "error": null,                        // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "delete",
   "state": "done",                     // The document has been fully deleted
@@ -317,7 +317,7 @@ You can receive the following types of notifications:
   },
   "requestId": "<unique request identifier>",
   "result": {                          // The updated document
-    "_id": "<unique document ID>",
+    "_id": "<documentId>",
     ...
   }
 }
@@ -332,8 +332,8 @@ You can receive the following types of notifications:
 {
   "status": 200,                        // Assuming everything went well
   "error": null,                        // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "create",
   "state": "pending",                   // Indicates that the document will be created
@@ -351,8 +351,8 @@ You can receive the following types of notifications:
 {
   "status": 200,                        // Assuming everything went well
   "error": null,                        // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "delete",
   "state": "pending",                   // Indicates that the document will be deleted
@@ -370,8 +370,8 @@ You can receive the following types of notifications:
 {
   "status": 200,                        // Assuming everything went well
   "error": null,                        // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "realtime",
   "action": "subscribe",
   "metadata": {
@@ -379,7 +379,7 @@ You can receive the following types of notifications:
   },
   "requestId": "<unique request identifier>",
   "result": {
-    "roomId": "<unique Kuzzle room ID>",
+    "roomId": "<unique Kuzzle room identifier>",
     "count": <the new user count on that room>
   }
 }
@@ -394,8 +394,8 @@ You can receive the following types of notifications:
 {
   "status": 200,                        // Assuming everything went well
   "error": null,                        // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "realtime",
   "action": "unsubscribe",
   "metadata": {
@@ -403,7 +403,7 @@ You can receive the following types of notifications:
   },
   "requestId": "<unique request identifier>",
   "result": {
-    "roomId": "<unique Kuzzle room ID>",
+    "roomId": "<unique Kuzzle room identifier>",
     "count": <the new user count on that room>
   }
 }

--- a/api-reference/source/includes/_querySyntax.md
+++ b/api-reference/source/includes/_querySyntax.md
@@ -41,10 +41,10 @@ to forward your queries to the right Kuzzle controller.
   "action": "<action>",
 
   // Index on which the action is handled (empty for actions that do not manage a unique index)
-  "index": "<data index>",
+  "index": "<index>",
 
   // Collection on which the action is handled (empty for actions that do not manage a unique collection)
-  "collection": "<data collection>",
+  "collection": "<collection>",
 
   // A set of filters matching documents you want to listen to
   "body": {..}
@@ -120,7 +120,7 @@ identify which query generated the response you got, the best way is to provide 
   "requestId": "<unique request identifier>",
   "controller": "<controller>",
   "action": "<action>",
-  "collection": "<data collection>",
+  "collection": "<collection>",
 
   // Request headers:
   "jwt": "<encrypted_jwt_token>"

--- a/api-reference/source/includes/_realtimeController.md
+++ b/api-reference/source/includes/_realtimeController.md
@@ -165,7 +165,7 @@ The `roomId` parameter is returned by Kuzzle when [subscribing](#subscribe) to s
 }
 ```
 
-List all subscriptions on all indexes and all collections.
+Lists all subscriptions on all indexes and all collections.
 
 
 ## publish
@@ -503,7 +503,7 @@ How subscription works:
 }
 ```
 
-This action instucts Kuzzle to detach you from its subscribers for the given room.
+Instructs Kuzzle to detach you from its subscribers for the given room.
 In practice, your subscription won't receive any new message on the room once this action is triggered.
 
 The expected parameter is the `roomId` that Kuzzle returned during the subscription.
@@ -562,7 +562,7 @@ The expected parameter is the `roomId` that Kuzzle returned during the subscript
 }
 ```
 
-Validate data against existing validation rules. The data is not published nor stored by Kuzzle
+Validates data against existing validation rules. The data is not published nor stored by Kuzzle
 If the document complies, the `result.valid` value is `true`, if not, it is `false`.
 When the document does not complies, both `result.errorMessages` contains some very detailed hints on what is wrong with the document.
 Note that if no validation specifications are set for the &lt;data index>/&lt;data collection>, the document always validate.

--- a/api-reference/source/includes/_realtimeController.md
+++ b/api-reference/source/includes/_realtimeController.md
@@ -15,8 +15,8 @@
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "realtime",
   "action": "count",
   "body": {
@@ -38,13 +38,13 @@
 {
   "status": 200,                        // Assuming everything went well
   "error": null,                        // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "realtime",
   "action": "count",
   "requestId": "<unique request identifier>",
   "result": {
-    "roomId": "<unique Kuzzle room ID>",
+    "roomId": "<unique Kuzzle room identifier>",
     "count": <number of subscriptions>,
   }
 }
@@ -69,12 +69,12 @@ The expected parameter is the roomId returned by Kuzzle during the subscription.
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "realtime",
   "action": "join",
   "body": {
-    "roomId": "<the room ID to join>"
+    "roomId": "<the room identifier to join>"
   },
   "metadata": {
     // query metadata
@@ -95,14 +95,14 @@ The expected parameter is the roomId returned by Kuzzle during the subscription.
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "realtime",
   "action": "subscribe",
   "metadata": {},                     // subscription metadata
   "requestId": "<unique request identifier>",
   "result": {
-    "roomId": "<unique Kuzzle room ID>"
+    "roomId": "<unique Kuzzle room identifier>"
   }
 }
 ```
@@ -112,11 +112,67 @@ Joins a previously created subscription.
 The `roomId` parameter is returned by Kuzzle when [subscribing](#subscribe) to some documents.
 
 
+## list
+
+<section class="http"></section>
+
+>**URL:** `http://kuzzle:7511/_listSubscriptions`  
+>**Method:** `GET`
+
+<section class="others"></section>
+
+>Query
+
+<section class="others"></section>
+
+```litcoffee
+{
+  "controller": "realtime",
+  "action": "list"
+}
+```
+
+>Response
+
+```litcoffee
+{
+  "error": null,
+  "status": 200,
+  "index": "<index>",
+  "collection": "<collection>",
+  "controller": "realtime",
+  "action": "publish",
+  "metadata": {},
+  "requestId": "<unique request identifier>",
+  "result": {
+    "<index>": {
+      "<collection>": {
+        "afcd909773f197ab859447594bfbd154": 12,
+        "4adbc1948ac4dc84ac89d14b488bcad1": 4,
+        ...
+      },
+      "<anotherCollection>": {
+        "bcd4ab54cdb4ad5b464ba4cd4564dc46": 1,
+        ...
+      },
+      ...
+    },
+    "<anotherIndex>": {
+      ...
+    },
+    ...
+  },
+}
+```
+
+List all subscriptions on all indexes and all collections.
+
+
 ## publish
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/<data collection>`  
+>**URL:** `http://kuzzle:7511/<index>/<collection>/_publish`  
 >**Method:** `POST`  
 >**Body:**
 
@@ -136,8 +192,8 @@ The `roomId` parameter is returned by Kuzzle when [subscribing](#subscribe) to s
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "realtime",
   "action": "publish",
   // The document itself
@@ -153,8 +209,8 @@ The `roomId` parameter is returned by Kuzzle when [subscribing](#subscribe) to s
 {
   "error": null,
   "status": 200,
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "realtime",
   "action": "publish",
   "metadata": {},
@@ -185,8 +241,8 @@ who have subscribed to a subscription for which the filters match the message co
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "realtime",
   "action": "subscribe",
   "body": {
@@ -251,15 +307,15 @@ who have subscribed to a subscription for which the filters match the message co
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "realtime",
   "action": "subscribe",
   "metadata": {},                     // subscription metadata
   "requestId": "<unique request identifier>",
   "result": {
-    "roomId": "<unique Kuzzle room ID>",
-    "channel": "<unique channel ID>"
+    "roomId": "<unique Kuzzle room identifier>",
+    "channel": "<unique channel identifier>"
   }
 }
 ```
@@ -339,18 +395,18 @@ who have subscribed to a subscription for which the filters match the message co
 
       /*
       {
-        "error":null,
-        "status":200,
-        "index":"<data index>",
-        "collection":""<data collection>"
-        "controller":"realtime",
-        "action":"subscribe",
+        "error": null,
+        "status": 200,
+        "index": "<index>",
+        "collection": "<collection>"
+        "controller": "realtime",
+        "action": "subscribe",
         "state": "done",
-        "metadata":{},
-        "result":{
-          "roomId":"632682a9eac95cfb95e3a697b29b7739",
-          "requestId":"mySubscription",
-          "timestamp":1449564937142
+        "metadata": {},
+        "result": {
+          "roomId": "632682a9eac95cfb95e3a697b29b7739",
+          "requestId": "mySubscription",
+          "timestamp": 1449564937142
         }
       }
       */
@@ -442,7 +498,7 @@ How subscription works:
   "metadata": {},                       // subscription metadata
   "requestId": "<unique request identifier>",
   "result": {
-    "roomId": "<unique Kuzzle room ID>"
+    "roomId": "<unique Kuzzle room identifier>"
   }
 }
 ```
@@ -457,7 +513,7 @@ The expected parameter is the `roomId` that Kuzzle returned during the subscript
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data index>/<data collection>/_validate`  
+>**URL:** `http://kuzzle:7511/<index>/<collection>/_validate`  
 >**Method:** `POST`  
 >**Body:**
 
@@ -477,8 +533,8 @@ The expected parameter is the `roomId` that Kuzzle returned during the subscript
 
 ```litcoffee
 {
-  index: "<data index>",
-  collection: "<data collection>",
+  index: "<index>",
+  collection: "<collection>",
   controller: "realtime",
   action: "validate",
   // The document itself
@@ -494,8 +550,8 @@ The expected parameter is the `roomId` that Kuzzle returned during the subscript
 {
   status: 200,                      // Assuming everything went well
   error: null,                      // Assuming everything went well
-  index: "<data index>",
-  collection: "<data collection>",
+  index: "<index>",
+  collection: "<collection>",
   controller: "realtime",
   action: "validate",
   metadata: {},

--- a/api-reference/source/includes/_securityController.md
+++ b/api-reference/source/includes/_securityController.md
@@ -1,11 +1,107 @@
 # ~ security controller
 
 
+## createFirstAdmin
+
+<section class="http"></section>
+
+>**URL:** `http://kuzzle:7511/<userId>/_createFirstAdmin[?reset=1]` or `http://kuzzle:7511/_createFirstAdmin[?reset=1]`  
+>**Method:** `POST`  
+>**Body**
+
+<section class="http"></section>
+
+```litcoffee
+{
+  "name": "John Doe",                     // Additional optional User properties
+  ...
+}
+
+// example with a "local" authentication
+
+{
+  "name": "John Doe",                     // Additional optional User properties
+  ...
+  "password": "MyPassword"                // ie: Mandatory for "local" authentication plugin
+}
+```
+
+<section class="others"></section>
+
+>Query
+
+<section class="others"></section>
+
+```litcoffee
+{
+  "controller": "security",
+  "action": "createFirstAdmin",
+  "reset": true|false,                    // Optional. Will reset the preset roles if set to true.
+  "_id": "<userId>",                      // Optional. If not provided, will be generated automatically.
+
+  "body": {
+    "profileIds": ["<profileId>"],       // Mandatory. The profile ids for the user
+    "name": "John Doe",                   // Additional optional User properties
+    ...
+  }
+}
+
+// example with a "local" authentication
+
+{
+  "controller": "security",
+  "action": "createFirstAdmin",
+  "reset": true|false,                    // Optional. Will reset the preset roles if set to true.
+  "_id": "<userId>",                      // Optional. If not provided, will be generated automatically.
+
+  "body": {
+    "profileIds": ["<profileId>"],        // Mandatory. The profile ids for the user
+    "name": "John Doe",                   // Additional optional User properties
+    ...
+    "password": "MyPassword"              // ie: Mandatory for "local" authentication plugin
+  }
+}
+```
+
+>Response
+
+```litcoffee
+{
+  "status": 200,                      // Assuming everything went well
+  "error": null,                      // Assuming everything went well
+  "controller": "security",
+  "action": "createFirstAdmin",
+  "metadata": {},
+  "requestId": "<unique request identifier>",
+  "result": {
+    "_id": "<user id, either provided or auto-generated>",
+    "_source": {
+      "name": "John Doe",
+      "profileIds": [
+        "admin"
+      ],
+      ...
+    }
+  }
+}
+```
+
+Creates the first admin `user` in Kuzzle's database layer. Does nothing if an admin user already exists.
+
+If an `_id` is provided in the query and if a `user` already exists with the given `_id`,
+it will be replaced and its `profileIds` will be set to `["admin"]`. If not provided, the `_id` will be auto-generated.
+
+If the optional field `reset` is set to `true` (`1` with http),
+the preset roles (`anonymous` and `default`) will be reset with more restrictive rights.
+
+Other mandatory additional informations are needed depending on the authentication plugins installed you want to use.
+
+
 ## createOrReplaceProfile
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/profiles/<profile_id>`  
+>**URL:** `http://kuzzle:7511/profiles/<profileId>`  
 >**Method:** `PUT`  
 >**Body**
 
@@ -16,10 +112,10 @@
   // The new array of role IDs and restrictions (cannot be empty)
   "roles": [
     {
-      "_id": "<roleID>"
+      "_id": "<roleId>"
     },
     {
-      "_id": "<roleID>",
+      "_id": "<anotherRoleId>",
       "restrictedTo": [
         {
           "index": "<index>"
@@ -48,17 +144,17 @@
 {
   "controller": "security",
   "action": "createOrReplaceProfile",
+  "_id": "<profileId>",
 
-  "_id": "<the profile id>",
   // the profile definition
   "body": {
     // The new array of role IDs and restrictions (cannot be empty)
     "roles": [
       {
-        "_id": "<roleID>"
+        "_id": "<roleId>"
       },
       {
-        "_id": "<roleID>",
+        "_id": "<roleId>",
         "restrictedTo": [
           {
             "index": "<index>"
@@ -82,10 +178,10 @@
 
 ```litcoffee
 {
-  "status":200,                       // Assuming everything went well
+  "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything wen well
   "result": {
-    "_id": "<profile_id>",
+    "_id": "<profileId>",
     "_index": "%kuzzle",
     "_type": "profiles",
     "_version": 1,
@@ -105,7 +201,7 @@ Creates (if no `_id` provided) or updates (if `_id` matches an existing one) a p
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/roles/<role id>` or `http://kuzzle:7511/roles/<role id>/_createOrReplace`  
+>**URL:** `http://kuzzle:7511/roles/<roleId>`  
 >**Method:** `PUT`  
 >**Body**
 
@@ -113,22 +209,10 @@ Creates (if no `_id` provided) or updates (if `_id` matches an existing one) a p
 
 ```litcoffee
 {
-  "indexes": {
-    "_canCreate": true,
+  "controllers": {
     "*": {
-      "_canDelete": true,
-      "collections": {
-        "_canCreate": true,
-        "*": {
-          "_canDelete": true,
-          "controllers": {
-            "*": {
-              "actions": {
-                "*": true
-              }
-            }
-          }
-        }
+      "actions": {
+        "*": true
       }
     }
   }
@@ -145,26 +229,14 @@ Creates (if no `_id` provided) or updates (if `_id` matches an existing one) a p
 {
   "controller": "security",
   "action": "createOrReplaceRole",
+  "_id": "<roleId>",
 
-  "_id": "<the role id>",
   // the role definition
   "body": {
-    "indexes": {
-      "_canCreate": true,
+    "controllers": {
       "*": {
-        "_canDelete": true,
-        "collections": {
-          "_canCreate": true,
-          "*": {
-            "_canDelete": true,
-            "controllers": {
-              "*": {
-                "actions": {
-                  "*": true
-                }
-              }
-            }
-          }
+        "actions": {
+          "*": true
         }
       }
     }
@@ -176,15 +248,23 @@ Creates (if no `_id` provided) or updates (if `_id` matches an existing one) a p
 
 ```litcoffee
 {
-  "status":200,                       // Assuming everything went well
-  error":null,                      // Assuming everything wen well
+  "status": 200,                     // Assuming everything went well
+  "error": null,                     // Assuming everything wen well
   "result": {
-    "_id": "<role id>",
+    "_id": "<roleId>",
     "_index": "%kuzzle",
     "_type": "roles",
     "_version": 1,
     "created": true,
-    "_source": {} // your role definition
+    "_source": { // your role definition
+      "controllers": {
+        "*": {
+          "actions": {
+            "*": true
+          }
+        }
+      }
+    }
   }
   "requestId": "<unique request identifier>",
   "controller": "security",
@@ -207,7 +287,7 @@ please refer to [Kuzzle's security documentation](https://github.com/kuzzleio/ku
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/users/<user id>`  
+>**URL:** `http://kuzzle:7511/users/<userId>`  
 >**Method:** `PUT`  
 >**Body**
 
@@ -215,8 +295,8 @@ please refer to [Kuzzle's security documentation](https://github.com/kuzzleio/ku
 
 ```litcoffee
 {
-  "profileId": "<profile id>",            // mandatory. The profile id for the user
-  "name": "John Doe",                     // Additional optional User properties
+  "profileIds": ["<profileId>", "anotherProfileId", "..."] // Mandatory. The profile ids for the user
+  "name": "John Doe",                                      // Additional optional User properties
   ...
 }
 ```
@@ -231,11 +311,10 @@ please refer to [Kuzzle's security documentation](https://github.com/kuzzleio/ku
 {
   "controller": "security",
   "action": "createOrReplaceUser",
-
-  "_id": "<the user id>",
+  "_id": "<userId>",
   "body": {
-    "profileId": "<profile id>",          // mandatory. The profile id for the user
-    "name": "John Doe",                   // Additional optional User properties
+    "profileIds": ["<profileId>", "anotherProfileId", "..."] // Mandatory. The profile ids for the user
+    "name": "John Doe",                                      // Additional optional User properties
     ...
   }
 }
@@ -254,10 +333,10 @@ please refer to [Kuzzle's security documentation](https://github.com/kuzzleio/ku
   "metadata": {},
   "requestId": "<unique request identifier>",
   "result": {
-    "_id": "<user id, either provided or auto-generated>",
+    "_id": "<userId>",
     "_index": "%kuzzle",
     "_source": {
-      "profileId": "<profile id>",
+      "profileIds": ["<profileId>", "anotherProfileId", "..."],
       "name": "John Doe",
       ...
     },
@@ -277,7 +356,7 @@ The `user` is created if it does not exists yet or replaced with the given objec
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/profiles/<profile id>/_create`  
+>**URL:** `http://kuzzle:7511/profiles/<profileId>/_create`  
 >**Method:** `POST`  
 >**Body**
 
@@ -288,10 +367,10 @@ The `user` is created if it does not exists yet or replaced with the given objec
   // The new array of role IDs and restrictions (cannot be empty)
   "policies": [
     {
-      "_id": "<roleID>"
+      "_id": "<roleId>"
     },
     {
-      "_id": "<roleID>",
+      "_id": "<roleId>",
       "restrictedTo": [
         {
           "index": "<index>"
@@ -320,17 +399,17 @@ The `user` is created if it does not exists yet or replaced with the given objec
 {
   "controller": "security",
   "action": "createProfile",
-  "_id": "<the profile id>",
+  "_id": "<profileId>",
 
   // the profile definition
   "body": {
     // The new array of role IDs and restrictions (cannot be empty)
     "policies": [
       {
-        "_id": "<roleID>"
+        "_id": "<roleId>"
       },
       {
-        "_id": "<roleID>",
+        "_id": "<roleId>",
         "restrictedTo": [
           {
             "index": "<index>"
@@ -354,10 +433,10 @@ The `user` is created if it does not exists yet or replaced with the given objec
 
 ```litcoffee
 {
-  "status":200,                       // Assuming everything went well
+  "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything wen well
   "result": {
-    "_id": "<profile_id>",
+    "_id": "<profileId>",
     "_index": "%kuzzle",
     "_type": "profiles",
     "_version": 1,
@@ -380,7 +459,7 @@ Creates a profile with a new list of roles.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/roles/<role id>/_create`  
+>**URL:** `http://kuzzle:7511/roles/<roleId>/_create`  
 >**Method:** `POST`  
 >**Body**
 
@@ -388,22 +467,10 @@ Creates a profile with a new list of roles.
 
 ```litcoffee
 {
-  "indexes": {
-    "_canCreate": true,
+  "controllers": {
     "*": {
-      "_canDelete": true,
-      "collections": {
-        "_canCreate": true,
-        "*": {
-          "_canDelete": true,
-          "controllers": {
-            "*": {
-              "actions": {
-                "*": true
-              }
-            }
-          }
-        }
+      "actions": {
+        "*": true
       }
     }
   }
@@ -420,26 +487,14 @@ Creates a profile with a new list of roles.
 {
   "controller": "security",
   "action": "createRole",
-  "_id": "<the role id>",
+  "_id": "<roleId>",
 
   // the role definition
   "body": {
-    "indexes": {
-      "_canCreate": true,
+    "controllers": {
       "*": {
-        "_canDelete": true,
-        "collections": {
-          "_canCreate": true,
-          "*": {
-            "_canDelete": true,
-            "controllers": {
-              "*": {
-                "actions": {
-                  "*": true
-                }
-              }
-            }
-          }
+        "actions": {
+          "*": true
         }
       }
     }
@@ -451,15 +506,23 @@ Creates a profile with a new list of roles.
 
 ```litcoffee
 {
-  "status":200,                       // Assuming everything went well
-  error":null,                      // Assuming everything wen well
+  "status": 200,                      // Assuming everything went well
+  "error": null,                      // Assuming everything wen well
   "result": {
-    "_id": "<role id>",
+    "_id": "<roleId>",
     "_index": "%kuzzle",
     "_type": "roles",
     "_version": 1,
     "created": true,
-    "_source": {} // your role definition
+    "_source": { // your role definition
+      "controllers": {
+        "*": {
+          "actions": {
+            "*": true
+          }
+        }
+      }
+    }
   }
   "requestId": "<unique request identifier>",
   "controller": "security",
@@ -483,7 +546,7 @@ please refer to [Kuzzle's security documentation](https://github.com/kuzzleio/ku
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/users/<user id>/_create` or `http://kuzzle:7511/users/_create`  
+>**URL:** `http://kuzzle:7511/users/<userId>/_create` or `http://kuzzle:7511/users/_create`  
 >**Method:** `POST`  
 >**Body**
 
@@ -491,7 +554,7 @@ please refer to [Kuzzle's security documentation](https://github.com/kuzzleio/ku
 
 ```litcoffee
 {
-  "profileIds": ["<profile id>"],         // Mandatory. The profile ids for the user
+  "profileIds": ["<profileId>"],          // Mandatory. The profile ids for the user
   "name": "John Doe",                     // Additional optional User properties
   ...
 }
@@ -499,7 +562,7 @@ please refer to [Kuzzle's security documentation](https://github.com/kuzzleio/ku
 // example with a "local" authentication
 
 {
-  "profileIds": ["<profile id>"],         // Mandatory. The profile ids for the user
+  "profileIds": ["<profileId>"],          // Mandatory. The profile ids for the user
   "name": "John Doe",                     // Additional optional User properties
   ...
   "password": "MyPassword"                // ie: Mandatory for "local" authentication plugin
@@ -516,10 +579,10 @@ please refer to [Kuzzle's security documentation](https://github.com/kuzzleio/ku
 {
   "controller": "security",
   "action": "createUser",
-  "_id": "<the user id>",                 // Optional. If not provided, will be generated automatically.
+  "_id": "<userId>",                      // Optional. If not provided, will be generated automatically.
 
   "body": {
-    "profileIds": ["<profile id>"],       // Mandatory. The profile ids for the user
+    "profileIds": ["<profileId>"],        // Mandatory. The profile ids for the user
     "name": "John Doe",                   // Additional optional User properties
     ...
   }
@@ -530,10 +593,10 @@ please refer to [Kuzzle's security documentation](https://github.com/kuzzleio/ku
 {
   "controller": "security",
   "action": "createUser",
-  "_id": "<the user id>",                 // Optional. If not provided, will be generated automatically.
+  "_id": "<userId>",                      // Optional. If not provided, will be generated automatically.
 
   "body": {
-    "profileIds": ["<profile id>"],       // Mandatory. The profile ids for the user
+    "profileIds": ["<profileId>"],        // Mandatory. The profile ids for the user
     "name": "John Doe",                   // Additional optional User properties
     ...
     "password": "MyPassword"              // ie: Mandatory for "local" authentication plugin
@@ -552,13 +615,12 @@ please refer to [Kuzzle's security documentation](https://github.com/kuzzleio/ku
   "controller": "security",
   "action": "createUser",
   "metadata": {},
-  "scope": null,
   "requestId": "<unique request identifier>",
   "result": {
     "_id": "<user id, either provided or auto-generated>",
     "_index": "%kuzzle",
     "_source": {
-      "profileIds": ["<profile id>"],
+      "profileIds": ["<profileId>"],
       "name": "John Doe",
       ...
     },
@@ -583,7 +645,7 @@ Other mandatory additional informations are needed depending on the authenticati
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/users/<user id>/_createRestricted` or `http://kuzzle:7511/users/_createRestricted`  
+>**URL:** `http://kuzzle:7511/users/<userId>/_createRestricted` or `http://kuzzle:7511/users/_createRestricted`  
 >**Method:** `POST`  
 >**Body**
 
@@ -614,8 +676,7 @@ Other mandatory additional informations are needed depending on the authenticati
 {
   "controller": "security",
   "action": "createRestrictedUser",
-
-  "_id": "<the user id>",                 // Optional. If not provided, will be generated automatically.
+  "_id": "<userId>",                      // Optional. If not provided, will be generated automatically.
   "body": {
     "name": "John Doe",                   // Additional optional User properties
     ...
@@ -627,8 +688,7 @@ Other mandatory additional informations are needed depending on the authenticati
 {
   "controller": "security",
   "action": "createRestrictedUser",
-
-  "_id": "<the user id>",                 // Optional. If not provided, will be generated automatically.
+  "_id": "<userId>",                      // Optional. If not provided, will be generated automatically.
   "body": {
     "name": "John Doe",                   // Additional optional User properties
     ...
@@ -648,13 +708,12 @@ Other mandatory additional informations are needed depending on the authenticati
   "controller": "security",
   "action": "createRestrictedUser",
   "metadata": {},
-  "scope": null,
   "requestId": "<unique request identifier>",
   "result": {
-    "_id": "<user id, either provided or auto-generated>",
+    "_id": "<userId>",
     "_index": "%kuzzle",
     "_source": {
-      "profileIds": ["<profile id>"],
+      "profileIds": ["<profileId>"],
       "name": "John Doe",
       ...
     },
@@ -680,7 +739,7 @@ Other mandatory additional informations are needed depending on the authenticati
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_profiles/<profile_id>`  
+>**URL:** `http://kuzzle:7511/_profiles/<profileId>`  
 >**Method:** `DELETE`
 
 <section class="others"></section>
@@ -696,7 +755,7 @@ Other mandatory additional informations are needed depending on the authenticati
 
   // The profile unique identifier. It's the same one that Kuzzle sends you
   // in its responses when you create a profile.
-  "_id": "<profile ID>"
+  "_id": "<profileId>"
 }
 ```
 
@@ -707,7 +766,7 @@ Other mandatory additional informations are needed depending on the authenticati
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
   "result": {
-    "_id": "<Profile ID>",        // The profile ID
+    "_id": "<profileId>",             // The profile id
   },
   "index": "%kuzzle",
   "collection": "profiles",
@@ -725,7 +784,7 @@ that the related roles will NOT be deleted.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/roles/<role id>`  
+>**URL:** `http://kuzzle:7511/roles/<roleId>`  
 >**Method:** `DELETE`
 
 <section class="others"></section>
@@ -741,7 +800,7 @@ that the related roles will NOT be deleted.
 
   // The role unique identifier. It's the same one that Kuzzle sends you
   // in its responses when you create a role.
-  "_id": "<role ID>"
+  "_id": "<roleId>"
 }
 ```
 
@@ -752,7 +811,7 @@ that the related roles will NOT be deleted.
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
   "result": {
-    "_id": "<Unique role ID>"         // The role ID
+    "_id": "<roleId>"                 // The role id
   }
   "index": "%kuzzle",
   "collection": "roles"
@@ -769,7 +828,7 @@ Given a `role id`, delete the corresponding role from the database.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/users/<user id>`  
+>**URL:** `http://kuzzle:7511/users/<userId>`  
 >**Method:** `DELETE`
 
 <section class="others"></section>
@@ -785,7 +844,7 @@ Given a `role id`, delete the corresponding role from the database.
 
   // The role unique identifier. It's the same one that Kuzzle sends you
   // in its responses when you create a role.
-  "_id": "<role ID>"
+  "_id": "<roleId>"
 }
 ```
 
@@ -796,7 +855,7 @@ Given a `role id`, delete the corresponding role from the database.
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
   "result": {
-    "_id": "<Unique role ID>"         // The role ID
+    "_id": "<roleId>"                 // The role id
   }
   "index": "%kuzzle",
   "collection": "users",
@@ -813,7 +872,7 @@ Given a `user id`, deletes the corresponding `user` from Kuzzle's database layer
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_profiles/<profile_id>`  
+>**URL:** `http://kuzzle:7511/_profiles/<profileId>`  
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -829,7 +888,7 @@ Given a `user id`, deletes the corresponding `user` from Kuzzle's database layer
 
   // The profile unique identifier. It's the same one that Kuzzle sends you
   // in its responses when you create a profile.
-  "_id": "<profile ID>"
+  "_id": "<profileId>"
 }
 ```
 
@@ -840,7 +899,7 @@ Given a `user id`, deletes the corresponding `user` from Kuzzle's database layer
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
   "result": {
-    "_id": "<Unique profile ID>",    // The profile ID
+    "_id": "<profileId>",             // The profile id
     "_source": {                      // The requested profile
       ...
     },
@@ -859,7 +918,7 @@ Given a `profile id`, retrieves the corresponding profile from the database.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_profiles/<profile_id>/_rights`  
+>**URL:** `http://kuzzle:7511/_profiles/<profileId>/_rights`  
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -875,7 +934,7 @@ Given a `profile id`, retrieves the corresponding profile from the database.
 
   // The profile unique identifier. It's the same one that Kuzzle sends you
   // in its responses when you create a profile.
-  "_id": "<profile ID>"
+  "_id": "<profileId>"
 }
 ```
 
@@ -924,7 +983,7 @@ Given a `profile id`, retrieves the corresponding rights.
 
   // The role unique identifier. It's the same one that Kuzzle sends you
   // in its responses when you create a role.
-  "_id": "<role ID>"
+  "_id": "<roleId>"
 }
 ```
 
@@ -935,7 +994,7 @@ Given a `profile id`, retrieves the corresponding rights.
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
   "result": {
-    "_id": "<Unique role ID>",        // The role ID
+    "_id": "<roleId>",                // The role id
     "_source": {
       "indexes": {
         ...
@@ -958,7 +1017,7 @@ Given a `role id`, retrieves the corresponding role from the database.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/users/<user id>`  
+>**URL:** `http://kuzzle:7511/users/<userId>`  
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -971,7 +1030,7 @@ Given a `role id`, retrieves the corresponding role from the database.
 {
   "controller": "security",
   "action": "getUser",
-  "_id": "<user id>"
+  "_id": "<userId>"
 }
 ```
 
@@ -981,16 +1040,16 @@ Given a `role id`, retrieves the corresponding role from the database.
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "security",
   "action": "getUser",
   "requestId": "<unique request identifier>",
   "result": {
-    "_id": "<user id>",
+    "_id": "<userId>",
     "_source": {
-      "profileId": "<profile id>",
-      ...                         // The user object content
+      "profileId": "<profileId>",
+      ...                             // The user object content
     }
   }
 }
@@ -1004,7 +1063,7 @@ Given a `user id`, gets the matching user from Kuzzle's dabatase layer.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_users/<user_id>/_rights`  
+>**URL:** `http://kuzzle:7511/_users/<userId>/_rights`  
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -1017,7 +1076,7 @@ Given a `user id`, gets the matching user from Kuzzle's dabatase layer.
 {
   "controller": "security",
   "action": "getUserRights",
-  "_id": "<user ID>"
+  "_id": "<userId>"
 }
 ```
 
@@ -1460,7 +1519,7 @@ Available filters:
     // An array of user objects
     "hits": [
       {
-        "_id": "<user id>",
+        "_id": "<userId>",
         "_source": { ... }             // The user object content
       },
       {
@@ -1480,8 +1539,8 @@ The `from` and `size` arguments allow pagination.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/profiles/<profile id>`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7511/profiles/<profile id>/_update`  
+>**Method:** `PUT`  
 >**Body**
 
 <section class="http"></section>
@@ -1490,10 +1549,10 @@ The `from` and `size` arguments allow pagination.
 {
     "policies": [
       {
-        "_id": "<roleID>"
+        "_id": "<roleId>"
       },
       {
-        "_id": "<roleID>",
+        "_id": "<roleId>",
         "restrictedTo": [
           {
             "index": "<index>"
@@ -1522,14 +1581,14 @@ The `from` and `size` arguments allow pagination.
 {
   "controller": "security",
   "action": "updateProfile",
-  "_id": "<profile id>",
+  "_id": "<profileId>",
   "body": {
     "policies": [
       {
-        "_id": "<roleID>"
+        "_id": "<roleId>"
       },
       {
-        "_id": "<roleID>",
+        "_id": "<roleId>",
         "restrictedTo": [
           {
             "index": "<index>"
@@ -1561,7 +1620,7 @@ The `from` and `size` arguments allow pagination.
   "controller": "security",
   "requestId": "<unique request identifier>",
   "result": {
-    "_id": "<user id>",
+    "_id": "<profileId>",
     "_index": "%kuzzle",
     "_type": "profiles",
     "_version": 2
@@ -1576,23 +1635,21 @@ Given a `profile id`, updates the matching Profile object in Kuzzle's database l
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/roles/<role id>`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7511/roles/<roleId>/_update`  
+>**Method:** `PUT`  
 >**Body**
 
 <section class="http"></section>
 
 ```litcoffee
 {
-    "indexes": {
-      "some index": {
-        "collections": {
-          "some collection": {
-            "_canDelete": true
-          }
-        }
+  "controllers": {
+    "*": {
+      "actions": {
+        "*": true
       }
     }
+  }
 }
 ```
 
@@ -1606,14 +1663,12 @@ Given a `profile id`, updates the matching Profile object in Kuzzle's database l
 {
   "controller": "security",
   "action": "updateRole",
-  "_id": "<role id>",
+  "_id": "<roleId>",
   "body": {
-    "indexes": {
-      "some index": {
-        "collections": {
-          "some collection": {
-            "_canDelete": true
-          }
+    "controllers": {
+      "*": {
+        "actions": {
+          "*": true
         }
       }
     }
@@ -1633,7 +1688,7 @@ Given a `profile id`, updates the matching Profile object in Kuzzle's database l
   "controller": "security",
   "requestId": "<unique request identifier>",
   "result": {
-    "_id": "<user id>",
+    "_id": "<roleId>",
     "_index": "%kuzzle",
     "_type": "roles",
     "_version": 2
@@ -1660,8 +1715,8 @@ please refer to [Kuzzle's security documentation](https://github.com/kuzzleio/ku
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/users/<user id>`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7511/users/<userId>/_update`  
+>**Method:** `PUT`  
 >**Body**
 
 <section class="http"></section>
@@ -1684,7 +1739,7 @@ please refer to [Kuzzle's security documentation](https://github.com/kuzzleio/ku
 {
   "controller": "security",
   "action": "updateUser",
-  "_id": "<user id>",
+  "_id": "<userId>",
   "body": {
     "foo": "bar",                    // Some properties to update
     "name": "Walter Smith",
@@ -1705,7 +1760,7 @@ please refer to [Kuzzle's security documentation](https://github.com/kuzzleio/ku
   "controller": "security",
   "requestId": "<unique request identifier>",
   "result": {
-    "_id": "<user id>",
+    "_id": "<userId>",
     "_index": "%kuzzle",
     "_type": "users",
     "_version": 2

--- a/api-reference/source/includes/_securityController.md
+++ b/api-reference/source/includes/_securityController.md
@@ -94,7 +94,7 @@ it will be replaced and its `profileIds` will be set to `["admin"]`. If not prov
 If the optional field `reset` is set to `true` (`1` with http),
 the preset roles (`anonymous` and `default`) will be reset with more restrictive rights.
 
-Other mandatory additional informations are needed depending on the authentication plugins installed you want to use.
+Other mandatory additional information are needed depending on the authentication plugins installed you want to use.
 
 
 ## createOrReplaceProfile
@@ -179,7 +179,7 @@ Other mandatory additional informations are needed depending on the authenticati
 ```litcoffee
 {
   "status": 200,                      // Assuming everything went well
-  "error": null,                      // Assuming everything wen well
+  "error": null,                      // Assuming everything went well
   "result": {
     "_id": "<profileId>",
     "_index": "%kuzzle",
@@ -249,7 +249,7 @@ Creates (if no `_id` provided) or updates (if `_id` matches an existing one) a p
 ```litcoffee
 {
   "status": 200,                     // Assuming everything went well
-  "error": null,                     // Assuming everything wen well
+  "error": null,                     // Assuming everything went well
   "result": {
     "_id": "<roleId>",
     "_index": "%kuzzle",
@@ -347,7 +347,7 @@ please refer to [Kuzzle's security documentation](https://github.com/kuzzleio/ku
 }
 ```
 
-Persist a `user` object to Kuzzle's database layer.
+Persists a `user` object to Kuzzle's database layer.
 
 The `user` is created if it does not exists yet or replaced with the given object if it does.
 
@@ -434,7 +434,7 @@ The `user` is created if it does not exists yet or replaced with the given objec
 ```litcoffee
 {
   "status": 200,                      // Assuming everything went well
-  "error": null,                      // Assuming everything wen well
+  "error": null,                      // Assuming everything went well
   "result": {
     "_id": "<profileId>",
     "_index": "%kuzzle",
@@ -507,7 +507,7 @@ Creates a profile with a new list of roles.
 ```litcoffee
 {
   "status": 200,                      // Assuming everything went well
-  "error": null,                      // Assuming everything wen well
+  "error": null,                      // Assuming everything went well
   "result": {
     "_id": "<roleId>",
     "_index": "%kuzzle",
@@ -638,7 +638,7 @@ If not provided, the `_id` will be auto-generated.
 
 Provided profile ids are used to set the permissions of the user.
 
-Other mandatory additional informations are needed depending on the authentication plugins installed you want to use.
+Other mandatory additional information are needed depending on the authentication plugins installed you want to use.
 
 
 ## createRestrictedUser
@@ -732,7 +732,7 @@ If not provided, the `_id` will be auto-generated.
 Profile ids are set accordingly to the Kuzzle configuration.
 This route is especially useful to allow anonymous users to create a user.
 
-Other mandatory additional informations are needed depending on the authentication plugins installed you want to use.
+Other mandatory additional information are needed depending on the authentication plugins installed you want to use.
 
 
 ## deleteProfile
@@ -821,7 +821,7 @@ that the related roles will NOT be deleted.
 }
 ```
 
-Given a `role id`, delete the corresponding role from the database.
+Given a `role id`, deletes the corresponding role from the database.
 
 
 ## deleteUser

--- a/api-reference/source/includes/_sendingMetadata.md
+++ b/api-reference/source/includes/_sendingMetadata.md
@@ -26,11 +26,11 @@ This feature is especially useful to include volatile information about the perf
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "update",
-  "_id": "<a document ID>",
+  "_id": "<documentId>",
   "body": {
     "somefield": "now has a new value"
   },
@@ -51,8 +51,8 @@ This feature is especially useful to include volatile information about the perf
 {
   "status": 200,
   "error": null,
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "document",
   "action": "update",
   "state": "pending",
@@ -83,8 +83,8 @@ This feature is especially useful to include volatile information about the perf
 
 ```litcoffee
 {
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "realtime",
   "action": "subscribe",
   "body": {
@@ -106,8 +106,8 @@ This feature is especially useful to include volatile information about the perf
 {
   "status": 200,
   "error": null,
-  "index": "<data index>",
-  "collection": "<data collection>",
+  "index": "<index>",
+  "collection": "<collection>",
   "controller": "realtime",
   "action": "unsubscribe",
   "state": "done",
@@ -117,7 +117,7 @@ This feature is especially useful to include volatile information about the perf
   },
   "requestId": "<unique request identifier>",
   "result": {
-    "roomId": "<uniqueKuzzleRoomID>",
+    "roomId": "<unique Kuzzle room identifier>",
     "count": <the new user count on that room>
   }
 }

--- a/api-reference/source/includes/_serverController.md
+++ b/api-reference/source/includes/_serverController.md
@@ -27,7 +27,7 @@
 {
   "status": 200,                      // Assuming everything went well
   "error": null,                      // Assuming everything went well
-  "index": "<data index>",
+  "index": "<index>",
   "action": "adminExists",
   "controller": "server",
   "requestId": "<unique request identifier>",
@@ -107,6 +107,312 @@ These statistics include:
 * the number of failed requests since the last frame
 
 Statistics are returned as a JSON-object with each key being the snapshot's timestamp (utc, in milliseconds).
+
+
+## getConfig
+
+
+<section class="http"></section>
+
+>**URL:** `http://kuzzle:7511/_getConfig`  
+>**Method:** `GET`
+
+<section class="others"></section>
+
+>Query
+
+<section class="others"></section>
+
+```litcoffee
+{
+  "controller": "server",
+  "action": "getConfig"
+}
+```
+
+>Response
+
+```litcoffee
+{
+  "status": 200,                      // Assuming everything went well
+  "error": null,                      // Assuming everything went well
+  "action": "getConfig",
+  "controller": "server",
+  "result": {
+    "kuzzle": {
+      "_": [
+        "start"
+      ],
+      "dump": {
+        "dateFormat": "YYYYMMDD-HHmm",
+        "enabled": false,
+        "gcore": "gcore",
+        "handledErrors": {
+          "enabled": true,
+          "whitelist": [
+            "RangeError",
+            "TypeError",
+            "KuzzleError",
+            "InternalError",
+            "PluginImplementationError"
+          ]
+        },
+        "path": "./dump/"
+      },
+      "http": {
+        "accessControlAllowOrigin": "*",
+        "routes": [
+          {
+            "action": "exists",
+            "controller": "collection",
+            "url": "/:index/:collection/_exists",
+            "verb": "get"
+          },
+          /*
+           * ... A long list of http routes ...
+           */
+        ]
+      },
+      "plugins": {
+        "common": {
+          "object": {},
+          "pipeTimeout": 250,
+          "pipeWarnTime": 40,
+          "workerPrefix": "kpw:"
+        },
+        "kuzzle-plugin-auth-passport-local": {
+          "activated": true,
+          "config": {
+            "algorithm": "sha1",
+            "digest": "hex",
+            "secret": "changeme"
+          },
+          "object": {},
+          "version": "3.0.2"
+        },
+        "kuzzle-plugin-logger": {
+          "activated": true,
+          "config": {
+            "services": {
+              "file": {
+                "addDate": true,
+                "outputs": {
+                  "error": {
+                    "filename": "kuzzle.log",
+                    "level": "warn"
+                  }
+                }
+              },
+              "stdout": {
+                "level": "info"
+              }
+            },
+            "threads": 2
+          },
+          "object": {},
+          "version": "2.0.5"
+        }
+      },
+      "queues": {
+        "cliQueue": "cli-queue"
+      },
+      "repositories": {
+        "common": {
+          "cacheTTL": 1440
+        }
+      },
+      "security": {
+        "default": {
+          "role": {
+            "controllers": {
+              "*": {
+                "actions": {
+                  "*": true
+                }
+              }
+            }
+          }
+        },
+        "jwt": {
+          "algorithm": "HS256",
+          "expiresIn": "1h",
+          "secret": "Kuzzle rocks"
+        },
+        "restrictedProfileIds": [
+          "default"
+        ],
+        "standard": {
+          "profiles": {
+            "admin": {
+              "policies": [
+                {
+                  "allowInternalIndex": true,
+                  "roleId": "admin"
+                }
+              ]
+            },
+            "anonymous": {
+              "policies": [
+                {
+                  "roleId": "anonymous"
+                }
+              ]
+            },
+            "default": {
+              "policies": [
+                {
+                  "roleId": "default"
+                }
+              ]
+            }
+          },
+          "roles": {
+            "admin": {
+              "controllers": {
+                "*": {
+                  "actions": {
+                    "*": true
+                  }
+                }
+              }
+            },
+            "anonymous": {
+              "controllers": {
+                "auth": {
+                  "actions": {
+                    "checkToken": true,
+                    "getCurrentUser": true,
+                    "getMyRights": true,
+                    "login": true
+                  }
+                },
+                "server": {
+                  "actions": {
+                    "info": true
+                  }
+                }
+              }
+            },
+            "default": {
+              "controllers": {
+                "auth": {
+                  "actions": {
+                    "checkToken": true,
+                    "getCurrentUser": true,
+                    "getMyRights": true,
+                    "logout": true,
+                    "updateSelf": true
+                  }
+                },
+                "server": {
+                  "actions": {
+                    "info": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "server": {
+        "maxConcurrentRequests": 50,
+        "maxRequestHistorySize": 50,
+        "maxRetainedRequests": 50000,
+        "warningRetainedRequestsLimit": 5000
+      },
+      "services": {
+        "common": {
+          "defaultInitTimeout": 10000,
+          "retryInterval": 1000
+        },
+        "db": {
+          "aliases": [
+            "storageEngine"
+          ],
+          "apiVersion": "5.0",
+          "backend": "elasticsearch",
+          "host": "elasticsearch",
+          "port": 9200
+        },
+        "garbageCollector": {
+          "cleanInterval": 86400000,
+          "maxDelete": 1000
+        },
+        "internalBroker": {
+          "aliases": [
+            "broker"
+          ],
+          "retryInterval": 1000,
+          "socket": "./run/broker.sock"
+        },
+        "internalCache": {
+          "backend": "redis",
+          "node": {
+            "host": "redis",
+            "port": 6379
+          }
+        },
+        "memoryStorage": {
+          "backend": "redis",
+          "database": 5,
+          "node": {
+            "host": "redis",
+            "port": 6379
+          }
+        },
+        "proxyBroker": {
+          "host": "proxy",
+          "port": 7331,
+          "retryInterval": 1000
+        }
+      },
+      "stats": {
+        "statsInterval": 10,
+        "ttl": 3600
+      },
+      "validation": {},
+      "version": "1.0.0-RC8"
+    },
+    "plugins": {
+      "config": {
+        "kuzzle-plugin-auth-passport-local": {
+          "activated": true,
+          "config": {
+            "algorithm": "sha1",
+            "digest": "hex",
+            "secret": "changeme"
+          },
+          "version": "3.0.2"
+        },
+        "kuzzle-plugin-logger": {
+          "activated": true,
+          "config": {
+            "services": {
+              "file": {
+                "addDate": true,
+                "outputs": {
+                  "error": {
+                    "filename": "kuzzle.log",
+                    "level": "warn"
+                  }
+                }
+              },
+              "stdout": {
+                "level": "info"
+              }
+            },
+            "threads": 2
+          },
+          "version": "2.0.5"
+        }
+      },
+      "routes": []
+    }
+  }
+}
+```
+
+Return the current Kuzzle configuration as loaded at Kuzzle start.
 
 
 ## getLastStats
@@ -402,4 +708,4 @@ Retrieves information about Kuzzle, its plugins and active services.
 }
 ```
 
-Return the the current Kuzzle UTC timestamp as Epoch time (number of milliseconds elapsed since 1 January 1970 00:00:00).
+Return the current Kuzzle UTC timestamp as Epoch time (number of milliseconds elapsed since 1 January 1970 00:00:00).

--- a/api-reference/source/includes/_serverController.md
+++ b/api-reference/source/includes/_serverController.md
@@ -412,7 +412,7 @@ Statistics are returned as a JSON-object with each key being the snapshot's time
 }
 ```
 
-Return the current Kuzzle configuration as loaded at Kuzzle start.
+Returns the current Kuzzle configuration as loaded at Kuzzle start.
 
 
 ## getLastStats
@@ -466,7 +466,7 @@ Return the current Kuzzle configuration as loaded at Kuzzle start.
 ```
 
 Kuzzle monitors its internal activities and make snapshots regularly.
-This command allows getting the last stored statistics frame.
+Allows to get the last stored statistics frame.
 By default, snapshots are made every 10s.
 
 These statistics include:
@@ -541,7 +541,7 @@ Statistics are returned as a JSON-object with each key being the snapshot's time
 }
 ```
 
-This command allows getting statistics frames saved/stored after a provided timestamp (utc, in milliseconds).
+Allows to get statistics frames saved/stored after a provided timestamp (utc, in milliseconds).
 
 These statistics include:
 
@@ -708,4 +708,4 @@ Retrieves information about Kuzzle, its plugins and active services.
 }
 ```
 
-Return the current Kuzzle UTC timestamp as Epoch time (number of milliseconds elapsed since 1 January 1970 00:00:00).
+Returns the current Kuzzle UTC timestamp as Epoch time (number of milliseconds elapsed since 1 January 1970 00:00:00).


### PR DESCRIPTION
* Document undocumented routes (kuzzleio/kuzzle-api-documentation#69)
* Align HTTP methods and action mandatory fields (kuzzleio/kuzzle#607)
* Document modifications of createFirstAdmin HTTP route (kuzzleio/kuzzle#606)
* Change the method of refreshInternal (was in fact not documented yet) (kuzzleio/kuzzle#603)
* Other boy scout modifications (see comments)