### PR TITLE
New Plugin management

### DIFF
--- a/guide/source/includes/essentials/_cli.md
+++ b/guide/source/includes/essentials/_cli.md
@@ -55,10 +55,6 @@ $ ./bin/kuzzle clearCache
 
 Kuzzle relies on the Redis service to store some frequently accessed internal data. If you need to restart Kuzzle with a fresh cache, this command can come in hand.
 
-### plugins
-
-Please refer to the [dedicated plugin CLI documentation](#managing-plugins-using-the-cli).
-
 ### reset
 
 ```

--- a/guide/source/includes/essentials/_plugins.md
+++ b/guide/source/includes/essentials/_plugins.md
@@ -121,7 +121,7 @@ A common practice is to copy the Plugin code in `plugins/available` and create a
 
 #### Configuring Plugins
 
-When initializing a Plugin, Kuzzle calls its `init(customConfig, context)` method, passing the [context](/plugin-reference/#the-plugin-context) and the custom configuration. Custom configuration parameters are specified for each plugin in the `plugins` object of the [Kuzzle configuration file](#configuring-kuzzle).
+When initializing a Plugin, Kuzzle (both Core and Proxy) calls its `init(customConfig, context)` method, passing the [context](/plugin-reference/#the-plugin-context) and the custom configuration. Custom configuration parameters are specified for each plugin in the `plugins` object of the [Kuzzle configuration file](#configuring-kuzzle).
 
 ```json
 {

--- a/guide/source/includes/essentials/_plugins.md
+++ b/guide/source/includes/essentials/_plugins.md
@@ -50,20 +50,23 @@ Kuzzle ships with a Protocol Plugin already bundled in its Community Edition, th
 
 This example is a very dummy one. We are going to install the **Hello World Controller Plugin**, which opens a new API endpoint that simply... Greets the client! Not very useful, except for the sake of this example.
 
-In Kuzzle, you can use the CLI to manage your Plugins. The `plugins --install` command enables you to install a Plugin from a Git repository, an NPM package or a local path on your machine.
+To install a Plugin, you just need to make it accessible within the `plugins/enabled` directory (relative to the path of the Kuzzle installation directory). A common practice is to copy the Plugin code in `plugins/available` and create a symbolic link in `plugins/enabled` pointing to it. This way, enabling and disabling a plugin is just a matter of creating or deleting a symbolic link.
 
 <aside class="notice">
-If you are running Kuzzle in a Docker container, you will need to enter the container to use the CLI.
+If you are running Kuzzle in a Docker container, you will need to enter the container to access the installation directory.
 </aside>
 
 Go to the Kuzzle installation directory and type:
 
 ```bash
-$ bin/kuzzle plugins --install --url https://github.com/kuzzleio/kuzzle-plugin-helloworld.git
+$ cd plugins/available
+$ git clone https://github.com/kuzzleio/kuzzle-plugin-helloworld.git
+$ cd ../enabled
+$ ln -s ../available/kuzzle-plugin-helloworld .
 $ pm2 restart KuzzleServer
 ```
 
-Once Kuzzle has restarted (that's what the second command is for) you can check the server information at `http://localhost:7511/?pretty=true` for the new `hello` endpoint:
+Once Kuzzle has restarted (that's what the last command is for) you can check the server information at `http://localhost:7511/?pretty=true` for the new `hello` endpoint:
 
 ```json
 {
@@ -106,254 +109,29 @@ Which means you can call the `http://localhost:7511/kuzzle-plugin-helloworld/hel
 
 To get a deeper insight on how Plugins work in Kuzzle, please refer to the [Plugin Reference](/plugin-reference).
 
-### Managing plugins using the CLI
+### Managing Plugins
 
-Plugins can be managed using the Kuzzle command-line interface:
+As seen in the previous example, managing Plugins is really just a matter of moving files and symbolic links around.
 
-```
-$ ./bin/kuzzle plugins --help
+#### Installing, removing, enabling and disabling Plugins
 
-  Usage: plugins [options] [name]
+When starting, Kuzzle (both Core and Proxy) looks for Plugins in the `plugins/enabled` directory. Valid Plugins are well-formed NPM modules (i.e. they have a `package.json` at their root) or simple NodeJS requireables (i.e. they have at their root a valid `index.js`).
 
-  manage plugins
+A common practice is to copy the Plugin code in `plugins/available` and create a symbolic link in `plugins/enabled` pointing to it. This way, enabling and disabling a plugin is just a matter of creating or deleting a symbolic link.
 
-  Options:
+#### Configuring Plugins
 
-    -h, --help                      output usage information
-        --list                      list currently installed plugins
-        --install                   if plugin [name] is provided, install it from --version, --url or --path, otherwise, (re-)install all listed plugins
-        --remove                    remove plugin [name] from Kuzzle
-        --activate                  mark the plugin as "activated"
-        --deactivate                mark the plugin as "deactivated"
-        --importConfig <file>       import plugin [name] configuration from <file>
-        --get                       get plugin [name] configuration stored in Kuzzle
-        --set <JSONObject>          merge plugin [name] configuration with JSONObject
-        --unset <property>          unset property from the plugin configuration
-        --replace <JSONObject>      erase the plugin configuration and apply JSONObject instead
-    -v, --packageVersion <version>  plugin <version> to install (npm repository or git only)
-    -u, --url <url>                 install plugin from a git repository or a remote tarball
-    -p, --path <path>               install plugin from the file system
+When initializing a Plugin, Kuzzle calls its `init(customConfig, context)` method, passing the [context](/plugin-reference/#the-plugin-context) and the custom configuration. Custom configuration parameters are specified for each plugin in the `plugins` object of the [Kuzzle configuration file](#configuring-kuzzle).
 
+```json
+{
+  "plugins": {
+    "kuzzle-plugin-blabla": {
+      "option_1": "option_value",
+      "option_2": "option_value"
+    }
+  }
+}
 ```
 
-<aside class="warning">Restarting Kuzzle is required to apply any change made to plugins using the command-line interface</aside>
-
-#### List installed plugins
-
-<aside class="note">Installed plugins are copied into the node_modules directory of a Kuzzle server instance, even if installed from a directory path</aside>
-
-You can get an overview of installed plugins and their activation status using the ``--list`` option:
-
-```
-./bin/kuzzle plugins --list
-{ 'kuzzle-plugin-logger':
-   { version: '2.0.4',
-     activated: true,
-     config:
-      { services:
-         { file:
-            { outputs: { error: { level: 'warn', filename: 'kuzzle.log' } },
-              addDate: true },
-           stdout: { level: 'info' } } } },
-  'kuzzle-plugin-auth-passport-local':
-   { version: '2.0.4',
-     activated: true,
-     config: { secret: 'changeme', algorithm: 'sha1', digest: 'hex' } } }
-```
-
-#### Install a plugin
-
-Kuzzle CLI supports most [npm installation methodes](https://docs.npmjs.com/cli/install).
-
-##### from npm repositories
-
-```shell
-$ kuzzle plugins --install [--packageVersion x.y.z] name
-```
-
-If `--packageVersion` is not provided, the `latest` version will be installed.
-
-##### from a git repository
-
-```shell
-$ kuzzle plugins --install [--packageVersion commit-ish] --url https://git.repository.url/project.git
-```
-
-The version can be anything related to commits: branch, tag, commit sha1.
-
-If no version is provided, the `master` branch is used.
-
-##### from a remote tarball
-
-```shell
-$ kuzzle plugins --install --url http://remote.com/plugin.tar.gz
-```
-
-<aside class="note">The tarball will be decompressed in the node_modules directory</aside>
-
-##### from a local tarball
-
-```shell
-$ kuzzle plugins --install --path /path/to/plugin.tar.gz
-```
-<aside class="note">The tarball will be decompressed in the node_modules directory</aside>
-
-##### from a local directory
-
-```shell
-$ kuzzle plgins --install --path /path/to/plugin
-```
-
-<aside class="note">The directory content will be copied in the node_modules directory</aside>
-
-#### View plugins configuration
-
-To view a plugin configuration, use the `--get` option.
-
-```
-$ ./bin/kuzzle plugins --get kuzzle-plugin-logger
-{ npmVersion: '2.0.2',
-  activated: true,
-  config:
-   { services:
-      { file:
-         { outputs:
-            { error: { level: 'error', filename: 'kuzzle-error.log' },
-              warning: { level: 'warn', filename: 'kuzzle-warning.log' } },
-           addDate: true },
-        stdout: { level: 'info', addDate: true } } } }
-```
-
-#### Modify a plugin configuration
-
-Plugin configurations are stored in the `config` part of plugins properties.
-
-There are multiple ways of changing a plugin configuration:
-
-* perform a partial update, using the ``--set`` action. This allows adding or updating parts of the configuration
-* replace the entire plugin configuration on the command-line, with the ``--replace`` action
-* replace the entire plugin configuration by loading a JSON file, with the ``--importConfig <file>`` action
-
-Updating a plugin configuration:
-
-```
-$ ./bin/kuzzle plugins --get kuzzle-plugin-logger
-{ version: '2.0.4',
-  activated: true,
-  config:
-   { services:
-      { file:
-         { outputs: { error: { level: 'warn', filename: 'kuzzle.log' } },
-           addDate: true },
-        stdout: { level: 'info' } } } }
-$ ./bin/kuzzle plugins --set '{ "stdout": { "level": "debug"} }' kuzzle-plugin-logger
-{ version: '2.0.4',
-  activated: true,
-  config:
-   { services:
-      { file:
-         { outputs: { error: { level: 'warn', filename: 'kuzzle.log' } },
-           addDate: true },
-        stdout: { level: 'info' } },
-     stdout: { level: 'debug' } } }
-```
-
-Replacing a plugin configuration on the command-line:
-
-```
-$ ./bin/kuzzle plugins --get kuzzle-plugin-logger
-
-{ version: '2.0.4',
-  activated: true,
-  config:
-   { services:
-      { file:
-         { outputs: { error: { level: 'warn', filename: 'kuzzle.log' } },
-           addDate: true },
-        stdout: { level: 'info' } } } }
-$ ./bin/kuzzle plugins --replace '{"stdout": {"level": "debug", "addDate": true}}' kuzzle-plugin-logger
-
-{ version: '2.0.4',
-  activated: true,
-  config: { stdout: { level: 'debug', addDate: true } } }
-```
-
-Replacing a plugin configuration using a JSON file:
-
-```
-$ ./bin/kuzzle plugins --importConfig foo.json kuzzle-plugin-logger
-[✔] Successfully imported configuration
-$ ./bin/kuzzle plugins --get kuzzle-plugin-logger
-{ npmVersion: '2.0.4', activated: true, config: { foo: 'bar' } }
-```
-
-
-#### Removing a plugin configuration property
-
-You can remove a plugin configuration property by using the ``--unset`` action:
-
-```
-$ ./bin/kuzzle plugins --get kuzzle-plugin-logger
-{ version: '2.0.4',
-  activated: true,
-  config:
-   { services:
-      { file:
-         { outputs:
-            { error: { level: 'error', filename: 'kuzzle-error.log' },
-              warning: { level: 'warn', filename: 'kuzzle-warning.log' } },
-           addDate: true },
-        stdout: { level: 'info', addDate: true } } } }
-$ ./bin/kuzzle plugins --unset 'services' kuzzle-plugin-logger
-  { npmVersion: '2.0.4',
-    activated: true }
-```
-<aside class="notice">NB: Only root properties can be unset</aside>
-
-#### Uninstalling a plugin
-
-Plugins can be uninstalled using the ``--remove`` option.
-
-```sh
-$ kuzzle plugins --remove kuzzle-plugin-socketio
-{ acknowledged: true }
-```
-
-#### Activating/Deactivating a plugin
-
-By default, a plugin is activated when installed, meaning it will be loaded and used by Kuzzle on the next restart.
-
-You may want to activate or deactivate a plugin, without uninstalling it.
-
-To deactivate a plugin:
-
-```
-./bin/kuzzle plugins --deactivate kuzzle-plugin-logger
-{ version: '2.0.4',
-  activated: false,
-  config:
-   { services:
-      { file:
-         { outputs:
-            { error: { level: 'error', filename: 'kuzzle-error.log' },
-              warning: { level: 'warn', filename: 'kuzzle-warning.log' } },
-           addDate: true },
-        stdout: { level: 'info', addDate: true } } } }
-```
-
-
-To activate a plugin:
-
-```
-$ ./bin/kuzzle plugins --activate kuzzle-plugin-logger
-  { version: '2.0.4',
-    activated: true,
-    config:
-     { services:
-        { file:__
-           { outputs:
-              { error: { level: 'error', filename: 'kuzzle-error.log' },
-                warning: { level: 'warn', filename: 'kuzzle-warning.log' } },
-             addDate: true },
-          stdout: { level: 'info', addDate: true } } } }
-```
+Each Plugin is responsible of handling the custom configuration parameters and Kuzzle has no opinion on how to do it. Whether the custom configuration is merged with the defaults or not entirely depends on the implementation of the `init` function.

--- a/guide/source/includes/essentials/_plugins.md
+++ b/guide/source/includes/essentials/_plugins.md
@@ -126,7 +126,7 @@ When initializing a Plugin, Kuzzle calls its `init(customConfig, context)` metho
 ```json
 {
   "plugins": {
-    "kuzzle-plugin-blabla": {
+    "kuzzle-plugin-foobar": {
       "option_1": "option_value",
       "option_2": "option_value"
     }

--- a/plugin-reference/source/includes/_creating-plugins.md
+++ b/plugin-reference/source/includes/_creating-plugins.md
@@ -83,12 +83,10 @@ As the Plugin is isolated in separated processes, the <a href="#the-plugin-conte
 Plugins enable you to add synchronous listener functions to a set of [events](#kuzzle-events-list). Listener functions are supplied with these events data, they are able to intercept the request, modify the data and interrupt its life-cycle.
 Kuzzle waits for their results before continuing the process.
 
-Synchronous
-
-Since `pipe` plugins are a part of how Kuzzle processes client requests, Kuzzle enforces a timeout on them, rejecting the request altogether if a `pipe` plugin fails to respond in a timely fashion, and forwarding an appropriate [GatewayTimeoutError](#gt-error-gatewaytimeouterror) error to the original client.  
+Synchronous listeners are a part of how Kuzzle processes client requests, thus Kuzzle enforces a timeout on them, rejecting the request altogether if a synchronous listener fails to respond in a timely fashion, and forwarding an appropriate [GatewayTimeoutError](#gt-error-gatewaytimeouterror) error to the original client.  
 The timeout value can be configured in Kuzzle configuration file.
 
-Asynchronous listeners are declared in the `pipes` property of the Plugin class, where the keys of the object are event names and the values are the names of the corresponding listeners.
+Synchronous listeners are declared in the `pipes` property of the Plugin class, where the keys of the object are event names and the values are the names of the corresponding listeners.
 Each listener function must also be exported.
 
 A single event can be listened by multiple synchronous listeners. When this is the case, they behave like middleware functions. Kuzzle calls them sequentially, without any particular order, piping the data from one function to the other.

--- a/plugin-reference/source/includes/_creating-plugins.md
+++ b/plugin-reference/source/includes/_creating-plugins.md
@@ -1,15 +1,21 @@
-# Plugin types
+# Plugin Features
 
-To plug itself to Kuzzle, a plugin exposes properties, telling Kuzzle what the plugin does, and how and when it should be invoked.
+Depending on the properties it exposes, a plugin can extend of one or several of the following features of Kuzzle:
 
-Depending on the properties it exposes, a plugin can be of one or several of the following types detailed below.
+* Core
+  - Listening asynchronously to events (on the same thread or a separate one),
+  - Listening synchronously to events (and intercept the Request life-cycle),
+  - Adding a controller route,
+  - Adding a new authentication strategy.
+* Proxy
+  - Adding a new communication protocol.
 
-## Listener plugins
+## Listening asynchronously
 
-`listener` plugins simply listen to events, and are supplied with these events data. These plugins cannot change the provided data, and Kuzzle does not wait for them to process the data either.
+Plugins enable you to add asynchronous listener functions to a set of [events](#kuzzle-events-list). Listener functions are supplied with these events data. These functions cannot change the provided data, and Kuzzle does not wait for them to process the data either.
 
-To configure a plugin as a `listener` on Kuzzle events, it needs to expose a `hooks` JSON object, linking Kuzzle events name with the names of plugin functions to execute.  
-Each function that Kuzzle needs to call must also be exposed.
+Asynchronous listeners are declared in the `hooks` property of the Plugin class, where the keys of the object are event names and the values are the names of the corresponding listeners.
+Each listener function must also be exported.
 
 **Example**
 
@@ -31,7 +37,7 @@ function MyPlugin () {
    Required plugin initialization function
    (see the "Plugin prerequisites" section)
    */
-  this.init = function (config, context) {
+  this.init = function (customConfig, context) {
     // initializes the plugin
   };
 
@@ -49,54 +55,48 @@ function MyPlugin () {
 module.exports = MyPlugin;
 ```
 
-## Worker plugins
+### Executing listeners in separate threads
 
-A `worker` plugin is simply a `listener` plugin running in separate processes. This is especially useful when you have to perform cost-heavy operations without impeding Kuzzle performances.
+Plugins declaring asynchronous listeners can also be executed in separate threads. This is handy when the listeners perform heavy computations that may corrupt the performances of the Kuzzle Core.
 
-To convert a `listener` plugin to a `worker` one, you only need to add the following attribute to the [plugin configuration](#gt-plugin-default-configuration): `threads: <number of threads>`
+To achieve this, Kuzzle must specify a `threads` property in the [custom configuration](/guide/#configuring-kuzzle) of the Plugin.
+
+```json
+{
+  "plugins": {
+    "kuzzle-plugin-blabla": {
+      "threads": 1
+    }
+  }
+}
+```
 
 If this number of threads is greater than 0, Kuzzle will launch the plugin on as many separate threads.  
 If there are more than 1 thread for that plugin, each time a listened event is fired, Kuzzle will pick one thread to notify using round-robin.
 
 <aside class="notice">
-As worker plugins are isolated in separated processes, the <a href="#the-plugin-context">plugin context</a> provided to worker plugins do not contain <code>accessors</code>
+As the Plugin is isolated in separated processes, the <a href="#the-plugin-context">plugin context</a> provided to worker plugins do not contain <code>accessors</code>
 </aside>
 
-Plugin configuration example:
+## Listening synchronously
 
-```json
-{
-  "version": "2.0.1",
-  "defaultConfig": {
-    "threads": 2
-  },
-  "activated": true
-}
-```
+Plugins enable you to add synchronous listener functions to a set of [events](#kuzzle-events-list). Listener functions are supplied with these events data, they are able to intercept the request, modify the data and interrupt its life-cycle.
+Kuzzle waits for their results before continuing the process.
 
-
-## Pipe plugins
-
-`pipe` plugins, like `listener` plugins, are attached to Kuzzle events, and they are supplied with these events data.  
-But unlike `listener` plugins, Kuzzle waits for their results before continuing the process.
-
-This means that `pipe` plugins may:
-
-* modify the provided data on the fly
-* instruct Kuzzle to abort the request, sending an immediate and custom answer to the requesting client
-
-Where a listener exposes a `hooks` property, a pipe plugin needs to expose its events in a `pipes` one, listing the listened events, and the plugin functions to invoke whenever these events are fired (see the example below).
+Synchronous
 
 Since `pipe` plugins are a part of how Kuzzle processes client requests, Kuzzle enforces a timeout on them, rejecting the request altogether if a `pipe` plugin fails to respond in a timely fashion, and forwarding an appropriate [GatewayTimeoutError](#gt-error-gatewaytimeouterror) error to the original client.  
 The timeout value can be configured in Kuzzle configuration file.
 
-A single event can be listened by multiple `pipe` plugins. When this is the case, Kuzzle calls the attached plugins sequentially, without any particular order.
+Asynchronous listeners are declared in the `pipes` property of the Plugin class, where the keys of the object are event names and the values are the names of the corresponding listeners.
+Each listener function must also be exported.
 
-`pipe` plugins functions take a callback as their last parameter, and this callback **must** be called at the end of the processing with the following arguments: `callback(error, object)`, where:
+A single event can be listened by multiple synchronous listeners. When this is the case, they behave like middleware functions. Kuzzle calls them sequentially, without any particular order, piping the data from one function to the other.
+
+Synchronous listener functions take a callback as their last parameter, which **must** be called at the end of the processing with the following arguments: `callback(error, object)`, where:
 
 * `error`: set this value to a `KuzzleError` object to make Kuzzle abort the request, and return that error to the client. Otherwise, set it to `null`
 * `object`: the resulting data, given back to Kuzzle for processing
-
 
 The following plugin example adds a `createdAt` attribute to all newly created documents:
 
@@ -119,7 +119,7 @@ function MyPlugin () {
     Required plugin initialization function
     (see the "Plugin prerequisites" section)
    */
-  this.init = function (config, context) {
+  this.init = function (customConfig, context) {
     // Plugin initialization
   };
 
@@ -134,12 +134,11 @@ function MyPlugin () {
 module.exports = MyPlugin;
 ```
 
-## Controller plugins
+## Adding a controller route
 
 Kuzzle API is divided into "controllers", each one of them exposing "actions" to execute (see [API reference](/api-reference/#common-attributes)).
 
-`controller` plugins extend Kuzzle API by adding new controllers to it, each with their own list of available actions.
-
+Plugins enable to add a set of new controllers to the Kuzzle public API, each with their own list of available actions.
 
 ### How is the API extended
 
@@ -147,8 +146,7 @@ To avoid name conflicts, added controllers are prefixed with the plugin name.
 
 Examples:
 
-- HTTP: `GET http://<server>:<port>/_plugin/<plugin name>/<url defined by the plugin>/<resources>`
-
+- HTTP: `GET http://<server>:<port>/<plugin name>/<url defined by the plugin>/<resources>`
 - Other protocols:
 
 ```javascript
@@ -159,14 +157,12 @@ Examples:
 }
 ```
 
-### How to implement a `controller` plugin
+### Implementing a controller route
 
-A controller plugin must expose to Kuzzle the following objects:
+To create a new controller, the Plugin must expose to Kuzzle the following objects:
 
-- A `controllers` object, describing the new controller to add. It will automatically be made available to any network protocol, except for HTTP
-
-- A `routes` objects, describing how the new controller should be exposed to the HTTP protocol. Only GET and POST verbs are accepted.
-
+- A `controllers` object, describing the new controller(s) to add. It will automatically be made available to any network protocol, except for HTTP
+- A `routes` objects, describing how the new controller(s) should be exposed to the HTTP protocol. Only GET and POST verbs are accepted.
 - Controller's actions functions. These methods take a `Request` object as an argument, and must return a `Promise` resolving with the action's result, or rejecting with a KuzzleError object.
 
 ### Controller plugin implementation example
@@ -193,8 +189,8 @@ function MyPlugin () {
    */
   this.controllers = {
     newController: {
-      myAction: 'actionImplementation',
-      myOtherAction: 'otherActionImplementation'
+      myAction: 'actionFunction',
+      myOtherAction: 'otherActionFunction'
     }
   };
 
@@ -207,14 +203,14 @@ function MyPlugin () {
     The first route exposes the following GET URL:
       http://<kuzzle server>:<port>/_plugin/<plugin name>/foo/<dynamic value>
 
-    Kuzzle will provide the function 'actionImplementation' with a Request object,
+    Kuzzle will provide the function 'actionFunction' with a Request object,
     containing the "name" property: request.input.args.name = '<dynamic value>'
 
     The second route exposes the following POST URL:
       http://<kuzzle server>:<port>/_plugin/<plugin name>/bar
 
     Kuzzle will provide the content body of the request in the Request object
-    passed to the function 'otherActionImplementation', in the request.input.body
+    passed to the function 'otherActionFunction', in the request.input.body
     property
    */
   this.routes = [
@@ -226,7 +222,7 @@ function MyPlugin () {
     Required plugin initialization function
     (see the "Plugin prerequisites" section)
    */
-  this.init = function (config, context) {
+  this.init = function (customConfig, context) {
     // plugin initialization
   };
 
@@ -240,7 +236,7 @@ function MyPlugin () {
     See the "How plugins receive action arguments" chapter just below
     for more information.
    */
-  this.actionImplementation = function (request) {
+  this.actionFunction = function (request) {
     // do action
 
     // optional: set network specific headers
@@ -263,7 +259,7 @@ function MyPlugin () {
     See the "How plugins receive action arguments" chapter just below
     for more information.
    */
-  this.otherActionImplementation = function (request) {
+  this.otherActionFunction = function (request) {
     // do action
     return Promise.resolve(/* result content */);
 
@@ -274,7 +270,7 @@ function MyPlugin () {
 module.exports = MyController;
 ```
 
-### How plugins receive action arguments
+### How Plugins receive action arguments
 
 All action functions receive a [Request](#gt-constructor-request) object as main argument. Kuzzle will fill it with arguments provided by clients invoking the added controller:
 
@@ -288,44 +284,115 @@ All action functions receive a [Request](#gt-constructor-request) object as main
   * the following fields at the root of the provided JSON objects are available in `request.input.resource`: `index`, `collection`, `_id`
   * any unrecognized property at the root of the provided JSON object will be stored in the `request.input.args` part of the `Request` object
 
+## Adding a new authentication strategy
 
-## Protocol plugins
+Kuzzle handles users security and authentication. The supported authentication strategies can be extended by Plugins.
 
-Kuzzle core only supports HTTP communications natively. All other supported protocols are implemented as `protocol` plugins.  
-By default, the Kuzzle official docker image is shipped with the following protocol plugins:
+Any strategy supported by [Passport](http://passportjs.org/) can be used to extend Kuzzle supported strategies, like we did with our official [OAUTH2 Authentication plugin](https://github.com/kuzzleio/kuzzle-plugin-auth-passport-oauth).  
+
+### Choose or implement a Passport strategy
+
+[Passport](http://passportjs.org) supports a wide range of authentication strategies. If that is not enough, you can also implement your own strategy for your authentication Plugin.
+
+In any case, the chosen strategy must be available in the Plugin local directory when Kuzzle installs it, either by adding the strategy in the Plugin's NPM dependencies, or by including the strategy code directly in the Plugin repository.
+
+### Create a verification function
+
+Since Kuzzle uses [Passport](http://passportjs.org) directly, using a strategy with Kuzzle is the same as using one with Passport.
+
+First, you have to implement a [`verify` function](http://passportjs.org/docs/configure), which will be provided to a Passport strategy constructor. This function is then used by the Passport strategy to authorize or to deny access to a user.
+
+The number of arguments taken by this `verify` function depends on the authentication strategy. For instance, a `local password` strategy needs the `verify` callback to be provided with an `user` name and his `password`.
+
+All strategies require this `verify` callback to take a `done` callback as its last argument, supplying Passport with the authenticated user's information.
+
+### Register the strategy to Kuzzle
+
+Once you chose a strategy and implemented its corresponding `verify` callback function, all you have to do is to register it to Kuzzle, using the `passport` accessor available in the plugin context:
+
+```js
+pluginContext.accessors.passport.use(strategy);
+```
+
+### (optional) Scope of access
+
+Some authentication procedures, like OAUTH 2.0, need a [scope of access](http://passportjs.org/docs/oauth) to be configured.
+
+Kuzzle Plugins support scope of access. To add one in your plugin, simply expose a `scope` attribute. Its format depends on the provider the strategy implements.
+
+
+### LocalStrategy Example
+
+<aside class="notice">
+Passport strategy constructors take a "verify" callback. As the following example demonstrates, if the provided callback uses "this.[attribute]" attributes, then it's necessary to bind the provided callback to the Plugin's context
+</aside>
+
+```javascript
+const LocalStrategy = require('passport-local').Strategy;
+
+function MyAuthenticationPlugin () {
+  this.context = null;
+
+  /*
+    Required plugin initialization function
+    (see the "Plugin prerequisites" section)
+   */
+  this.init = function (customConfig, pluginContext) {
+    this.context = pluginContext;
+
+    this.context.accessors.passport.use(new LocalStrategy(this.verify.bind(this)));
+  }
+
+  this.verify = function (username, password, done) {
+    // Code performing the necessary verifications
+    if (success) {
+      done(null, this.context.accessors.users.load(username));
+    }
+    else {
+      done(new this.context.errors.ForbiddenError('Login failed'));
+    }
+  };
+};
+
+// Exports the plugin objects, allowing Kuzzle to instantiate it
+module.exports = MyAuthenticationPlugin;
+```
+
+## Adding a new communication protocol
+
+Kuzzle core only supports HTTP communications natively. All other supported protocols are implemented by Plugins installed on the Kuzzle Proxy.
+By default, the Kuzzle Proxy official docker image is shipped with the following protocol plugins:
 
 * [Socket.io](https://www.npmjs.com/package/kuzzle-plugin-socketio)
 * [WebSocket](https://www.npmjs.com/package/kuzzle-plugin-websocket)
 
 ### How it works
 
-Requests sent by clients can be forwarded to Kuzzle by protocol plugins using the [`router` accessor](#gt-accessor-router)  
-To access these methods, simply call ``context.accessors.router.<router method>``:
+Requests sent by clients can be forwarded to Kuzzle using the [`router` accessor](#gt-accessor-router)  
+To access these methods, simply call `context.accessors.router.<router method>`:
 
 | Router method | Arguments    | Returns | Description              |
 |-----------------|--------------|---------|--------------------------|
-| ``newConnection`` | ``protocol name`` (string) <br/>``connection ID`` (string) | A promise resolving to a ``RequestContext`` object | Declares a new connection to Kuzzle. |
-| ``execute`` | ``request`` ([Request](#gt-constructor-request) object)<br/>``callback`` (a callback resolved with Kuzzle's response) |  | Executes a client request. |
-| ``removeConnection`` | ``RequestContext`` (obtained with ``newConnection``) | | Asks Kuzzle to remove the corresponding connection and all its subscriptions |
+| `newConnection` | `protocol name` (string) <br/>`connection ID` (string) | A promise resolving to a `RequestContext` object | Declares a new connection to Kuzzle. |
+| `execute` | `request` ([Request](#gt-constructor-request) object)<br/>`callback` (a callback resolved with Kuzzle's response) |  | Executes a client request. |
+| `removeConnection` | `RequestContext` (obtained with `newConnection`) | | Asks Kuzzle to remove the corresponding connection and all its subscriptions |
 
-
-Kuzzle expects `protocol` plugins to expose the following methods:
+Kuzzle Proxy expects Protocol Plugins to expose the following methods:
 
 | Method | Arguments | Description                 |
 |------|----------------|-----------------------------|
-| ``init`` | `pluginConfiguration, context` | [Plugin initialization function](#gt-plugin-init-function) |
-| ``joinChannel`` | `{channel, id}`| Tells protocol plugins that the connection `id` subscribed to the channel `channel` |
-| ``leaveChannel`` | `{channel, id}` | Tells protocol plugins that the connection `id` left the channel `channel` |
-| ``notify`` | `{channels, id, payload}` | Asks protocol plugins to emit a data `payload` (JSON Object) to the connection `id` (string), on the channels  `channels` (array of strings)|
-| ``broadcast`` | `{channels, payload}` | Asks protocol plugins to emit a data `payload` (JSON Object) to clients connected to the channels list `channels` (array of strings) |
-| ``disconnect`` | `id` | Asks protocol plugins to force-close the connection `id` |
+| `init` | `pluginConfiguration, context` | [Plugin initialization function](#gt-plugin-init-function) |
+| `joinChannel` | `{channel, id}`| Tells Protocol Plugins that the connection `id` subscribed to the channel `channel` |
+| `leaveChannel` | `{channel, id}` | Tells Protocol Plugins that the connection `id` left the channel `channel` |
+| `notify` | `{channels, id, payload}` | Asks Protocol Plugins to emit a data `payload` (JSON Object) to the connection `id` (string), on the channels  `channels` (array of strings)|
+| `broadcast` | `{channels, payload}` | Asks Protocol Plugins to emit a data `payload` (JSON Object) to clients connected to the channels list `channels` (array of strings) |
+| `disconnect` | `id` | Asks protocol plugins to force-close the connection `id` |
 
-The connection `id` Kuzzle sends to plugins is the one declared by `protocol` plugins using `context.accessors.router.newConnection`.
+The connection `id` Kuzzle sends to Plugins is the one declared by Protocol Plugins using `context.accessors.router.newConnection`.
 
 *For more information about channels, see our [API Documentation](/api-reference/#subscribe)*
 
-
-### `protocol` plugin implementation example
+### Implementation example
 
 ```javascript
 function MyPlugin () {
@@ -338,7 +405,7 @@ function MyPlugin () {
    Required plugin initialization function
    (see the "Plugin prerequisites" section)
   */
-  this.init = function (config, context) {
+  this.init = function (customConfig, context) {
     // plugin initialization
     this.pluginContext = context;
   };
@@ -430,74 +497,3 @@ module.exports = MyPlugin;
 ```
 
 
-## Authentication plugin
-
-Kuzzle handles users security and authentication. The supported authentication strategies can be extended using `authentication` plugins.
-
-Any strategy supported by [Passport](http://passportjs.org/) can be used to extend Kuzzle supported strategies, like we did with our official [OAUTH2 Authentication plugin](https://github.com/kuzzleio/kuzzle-plugin-auth-passport-oauth).  
-
-### Choose or implement a Passport strategy
-
-[Passport](http://passportjs.org) supports a wide range of authentication strategies. If that is not enough, you can also implement your own strategy for your authentication plugin.
-
-In any case, the chosen strategy must be available in the plugin local directory when Kuzzle installs it, either by adding the strategy in the plugin's NPM dependencies, or by including the strategy code directly in the plugin repository.
-
-### Create a verification function
-
-Since Kuzzle uses [Passport](http://passportjs.org) directly, using a strategy with Kuzzle is the same than using one with Passport.
-
-First, you have to implement a [`verify` function](http://passportjs.org/docs/configure), which will be provided to a Passport strategy constructor. This function is then used by the Passport strategy to authorize or to deny access to a user.
-
-The number of arguments taken by this `verify` function depends on the authentication strategy. For instance, a `local password` strategy needs the `verify` callback to be provided with an `user` name and his `password`.
-
-All strategies require this `verify` callback to take a `done` callback as its last argument, supplying Passport with the authenticated user's information.
-
-### Register the strategy to Kuzzle
-
-Once you chose a strategy and implemented its corresponding `verify` callback function, all you have to do is to register it to Kuzzle, using the `passport` accessor available in the plugin context:
-
-```js
-pluginContext.accessors.passport.use(strategy);
-```
-
-### (optional) Scope of access
-
-Some authentication procedures, like OAUTH 2.0, need a [scope of access](http://passportjs.org/docs/oauth) to be configured.
-
-Kuzzle authentication plugins support scope of access. To add one in your plugin, simply expose a `scope` attribute. Its format depends on the provider the strategy implements.
-
-
-### Authentication plugin example, using the LocalStrategy strategy
-
-<aside class="notice">Passport strategy constructors take a "verify" callback. As the following example demonstrates, if the provided callback uses "this.[attribute]" attributes, then it's necessary to bind the provided callback to the plugin's context</aside>
-
-```javascript
-const LocalStrategy = require('passport-local').Strategy;
-
-function MyAuthenticationPlugin () {
-  this.context = null;
-
-  /*
-    Required plugin initialization function
-    (see the "Plugin prerequisites" section)
-   */
-  this.init = function (pluginConfiguration, pluginContext) {
-    this.context = pluginContext;
-
-    this.context.accessors.passport.use(new LocalStrategy(this.verify.bind(this)));
-  }
-
-  this.verify = function (username, password, done) {
-    // Code performing the necessary verifications
-    if (success) {
-      done(null, this.context.accessors.users.load(username));
-    }
-    else {
-      done(new this.context.errors.ForbiddenError('Login failed'));
-    }
-  };
-};
-
-// Exports the plugin objects, allowing Kuzzle to instantiate it
-module.exports = MyAuthenticationPlugin;
-```

--- a/plugin-reference/source/includes/_kuzzle-events.md
+++ b/plugin-reference/source/includes/_kuzzle-events.md
@@ -6,8 +6,8 @@ Every time Kuzzle receives a request coming from a client, it routes it towards 
 
 Events triggered when a request is treated in the [`auth` controller](/api-reference/#auth-controller)
 
-| Event                 | Description                                                        | Payload         |
-|-----------------------|--------------------------------------------------------------------|---------------|
+| Event | Description | Payload |
+|-------|-------------|---------|
 | `auth:after<Action>`  | All actions in `auth` controller trigger an event after executing  | Type: Request |
 | `auth:before<Action>` | All actions in `auth` controller trigger an event before executing | Type: Request |
 
@@ -16,8 +16,8 @@ Events triggered when a request is treated in the [`auth` controller](/api-refer
 
 Events triggered when a request is treated in the [`bulk` controller](/api-reference/#bulk-controller)
 
-| Event               | Description                                                                 | Payload         |
-|---------------------|-----------------------------------------------------------------------------|---------------|
+| Event | Description | Payload |
+|-------|-------------|---------|
 | `bulk:afterImport`  | The `import` action in `bulk` controller triggers an event after executing  | Type: Request |
 | `bulk:beforeImport` | The `import` action in `bulk` controller triggers an event before executing | Type: Request |
 
@@ -26,8 +26,8 @@ Events triggered when a request is treated in the [`bulk` controller](/api-refer
 
 Events triggered when a database reset is asked to the command-line interface.
 
-| Event                   | Description                                                      | Payload                                                                                         |
-|-------------------------|------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
+| Event | Description | Payload |
+|-------|-------------|---------|
 | `cleanDb:deleteIndexes` | Triggered during `cleanDb` process just before indexes deletion. | Type: Request object.<br> Contains all indexes to delete in `requestObject.data.body.indexes` |
 | `cleanDb:done`          | Triggered after indexes deletion.                                | /                                                                                             |
 | `cleanDb:error`         | Triggered when an error occurred on clean db                     | Type: Error                                                                                   |
@@ -37,8 +37,8 @@ Events triggered when a database reset is asked to the command-line interface.
 
 Events triggered when a request is treated in the [`collection` controller](/api-reference/#collection-controller).
 
-| Event                       | Description                                                              | Payload         |
-|-----------------------------|--------------------------------------------------------------------------|---------------|
+| Event | Description | Payload |
+|-------|-------------|---------|
 | `collection:after<Action>`  | All actions in `collection` controller trigger an event after executing  | Type: Request |
 | `collection:before<Action>` | All actions in `collection` controller trigger an event before executing | Type: Request |
 
@@ -47,8 +47,8 @@ Events triggered when a request is treated in the [`collection` controller](/api
 
 Events triggered to synchronize Kuzzle server instances in a cluster.
 
-| Event                                   | Description                                                            | Payload                |
-|-----------------------------------------|------------------------------------------------------------------------|----------------------|
+| Event | Description | Payload |
+|-------|-------------|---------|
 | `core:kuzzleStart`                      | Emitted when Kuzzle is started                                         | /                    |
 | `core:hotelClerk:addSubscription`       | Sends a diff containing the filters and internal hotelClerk updates    | hcR object           |
 | `core:hotelClerk:join`                  | Sends hotelClerk diff when a room is joined                            | hcR object           |
@@ -63,8 +63,8 @@ Events triggered to synchronize Kuzzle server instances in a cluster.
 
 Events triggered when a request is treated in the [`index` controller](/api-reference/#index-controller).
 
-| Event                  | Description                                                         | Payload         |
-|------------------------|---------------------------------------------------------------------|---------------|
+| Event | Description | Payload |
+|-------|-------------|---------|
 | `index:after<Action>`  | All actions in `index` controller trigger an event after executing  | Type: Request |
 | `index:before<Action>` | All actions in `index` controller trigger an event before executing | Type: Request |
 
@@ -73,15 +73,15 @@ Events triggered when a request is treated in the [`index` controller](/api-refe
 
 Events triggered when a request is treated in the [`document` controller](/api-reference/#document-controller).
 
-| Event                     | Description                                                            | Payload         |
-|---------------------------|------------------------------------------------------------------------|---------------|
+| Event | Description | Payload |
+|-------|-------------|---------|
 | `document:after<Action>`  | All actions in `document` controller trigger an event after executing  | Type: Request |
 | `document:before<Action>` | All actions in `document` controller trigger an event before executing | Type: Request |
 
 ## http
 
-| Event                     | Description                                                            | Payload         |
-|---------------------------|------------------------------------------------------------------------|---------------|
+| Event | Description | Payload |
+|-------|-------------|---------|
 | `http:options` | Triggered whenever a HTTP OPTIONS methods is handled | Type: Request |
 
 ## internalBroker
@@ -90,8 +90,8 @@ Events triggered when a request is treated in the [`document` controller](/api-r
 
 Events triggered by the Kuzzle internal message broker, used to transmit data between Kuzzle instances.
 
-| Event                          | Description                                        | Payload                                                |
-|--------------------------------|----------------------------------------------------|------------------------------------------------------|
+| Event | Description | Payload |
+|-------|-------------|---------|
 | `internalBroker:connected`     | Triggered when the internal broker is connected    | Type: String.<br> `'Connected to Kuzzle server'`     |
 | `internalBroker:error`         | Triggered when an error occured in internal broker | Type: Object.<br> {host, port, message, retry}       |
 | `internalBroker:reregistering` | Triggered when the internal broker is reregistered | Type: String.<br> `'Re-registering room: ' + room`   |
@@ -103,8 +103,8 @@ Events triggered by the Kuzzle internal message broker, used to transmit data be
 
 Events triggered when a request is sent to the [`memoryStorage` controller](/#memorystorage-controller).
 
-| Event              | Description                                                                 | Payload         |
-|--------------------|-----------------------------------------------------------------------------|---------------|
+| Event | Description | Payload |
+|-------|-------------|---------|
 |`ms:after<Action>`  | All actions in `memoryStorage` controller trigger an event after executing  | Type: Request |
 |`ms:before<Action>` | All actions in `memoryStorage` controller trigger an event before executing | Type: Request |
 
@@ -113,8 +113,8 @@ Events triggered when a request is sent to the [`memoryStorage` controller](/#me
 
 Events triggered during Kuzzle startup, when the database is prepared for Kuzzle's use.
 
-| Event                             | Description                                                                      | Payload                                                                                                   |
-|-----------------------------------|----------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
+| Event | Description | Payload |
+|-------|-------------|---------|
 | `prepareDb:createFixturesIndex`   | Triggered during database preparation. Called for each index in fixtures         | Type: Request.<br> Contains the index to create in `requestObject.index`                                |
 | `prepareDb:createInternalIndex`   | Triggered on Kuzzle start to create the internal index `%kuzzle`                 | Type: Request.<br> Contains the internal index in `requestObject.index`                                 |
 | `prepareDb:error`                 | Triggered when an error occurred during database preparation                     | Type: Error.                                                                                            |
@@ -129,8 +129,8 @@ Events triggered during Kuzzle startup, when the database is prepared for Kuzzle
 
 Events triggered when interacting with `proxy`.
 
-| Event                | Description                                                                               | Payload                                                                                                                                                                          |
-|----------------------|-------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Event | Description | Payload |
+|-------|-------------|---------|
 | `proxy:broadcast`    | Triggered before broadcast. You can't modify the input on this event                      | Type: Object.<br> `{payload, channelsList}`<br> `payload` is the notification content. <br>`channelsList` is an array of channels to broadcast.                                |
 | `proxy:joinChannel`  | Triggered after attaching a user to a room. You can't modify the input on this event      | Type: Object.<br> `{channel, id}`<br> `channel` is the channel name.<br> `id` is the connection id                                                                             |
 | `proxy:leaveChannel` | Triggered before a room is removed for the user. You can't modify the input on this event | Type: Object.<br> `{channel, id}`<br> `channel` is the channel name.<br> `id` is the connection id                                                                             |
@@ -141,8 +141,8 @@ Events triggered when interacting with `proxy`.
 
 Events triggered when a request is sent to the [`realtime` controller](/api-reference/#realtime-controller).
 
-| Event                    | Description                                                            | Payload         |
-|--------------------------|------------------------------------------------------------------------|---------------|
+| Event | Description | Payload |
+|-------|-------------|---------|
 |`realtime:after<Action>`  | All actions in `realtime` controller trigger an event after executing  | Type: Request |
 |`realtime:before<Action>` | All actions in `realtime` controller trigger an event before executing | Type: Request |
 
@@ -150,8 +150,8 @@ Events triggered when a request is sent to the [`realtime` controller](/api-refe
 
 Events triggered on subscription rooms activity.
 
-| Event         | Description                                                                                    | Payload                                                              |
-|---------------|------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
+| Event | Description | Payload |
+|-------|-------------|---------|
 | `room:new`    | Triggered when a new room is added in the rooms list. You can't modify the input on this event | Type: Object. <br> `{roomId, index, collection, formattedFilters}` |
 | `room:remove` | Triggered after a room is removed from the list. You can't modify the input on this event      | Type: String.<br> The room id                                      |
 
@@ -160,8 +160,8 @@ Events triggered on subscription rooms activity.
 
 Events triggered when a request is sent to the [`security` controller](/api-reference/#security-controller).
 
-| Event                                 | Description                                                                           | Payload         |
-|---------------------------------------|---------------------------------------------------------------------------------------|---------------|
+| Event | Description | Payload |
+|-------|-------------|---------|
 | `security:after<Action>`              | All actions in `security` controller trigger an event after executing                 | Type: Request |
 | `security:before<Action>`             | All actions in `security` controller trigger an event before executing                | Type: Request |
 | `security:formatUserForSerialization` | Triggered before serializing a user. Useful to clean a user like attribute `password` | Type: User    |
@@ -171,7 +171,7 @@ Events triggered when a request is sent to the [`security` controller](/api-refe
 
 Events triggered on server special events or when a request is sent to the [`server` controller](/api-reference/#server-controller).
 
-| Event                   | Description                                                          | Payload                                                                 |
-|-------------------------|----------------------------------------------------------------------|-----------------------------------------------------------------------|
+| Event | Description | Payload |
+|-------|-------------|---------|
 | `server:after<Action>`  | All actions in `server` controller trigger an event after executing  | Type: Request                                                         |
 | `server:before<Action>` | All actions in `server` controller trigger an event before executing | Type: Request                                                         |

--- a/plugin-reference/source/includes/_kuzzle-events.md
+++ b/plugin-reference/source/includes/_kuzzle-events.md
@@ -1,11 +1,12 @@
 # Kuzzle events list
 
+Every time Kuzzle receives a request coming from a client, it routes it towards a Controller and an Action, that process it and send the results back to the client. Each step of this life-cycle triggers an event. Below are the different types of events that Plugins can listen to.
 
 ## auth
 
 Events triggered when a request is treated in the [`auth` controller](/api-reference/#auth-controller)
 
-| Event                 | Description                                                        | Input         |
+| Event                 | Description                                                        | Payload         |
 |-----------------------|--------------------------------------------------------------------|---------------|
 | `auth:after<Action>`  | All actions in `auth` controller trigger an event after executing  | Type: Request |
 | `auth:before<Action>` | All actions in `auth` controller trigger an event before executing | Type: Request |
@@ -15,7 +16,7 @@ Events triggered when a request is treated in the [`auth` controller](/api-refer
 
 Events triggered when a request is treated in the [`bulk` controller](/api-reference/#bulk-controller)
 
-| Event               | Description                                                                 | Input         |
+| Event               | Description                                                                 | Payload         |
 |---------------------|-----------------------------------------------------------------------------|---------------|
 | `bulk:afterImport`  | The `import` action in `bulk` controller triggers an event after executing  | Type: Request |
 | `bulk:beforeImport` | The `import` action in `bulk` controller triggers an event before executing | Type: Request |
@@ -25,7 +26,7 @@ Events triggered when a request is treated in the [`bulk` controller](/api-refer
 
 Events triggered when a database reset is asked to the command-line interface.
 
-| Event                   | Description                                                      | Input                                                                                         |
+| Event                   | Description                                                      | Payload                                                                                         |
 |-------------------------|------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
 | `cleanDb:deleteIndexes` | Triggered during `cleanDb` process just before indexes deletion. | Type: Request object.<br> Contains all indexes to delete in `requestObject.data.body.indexes` |
 | `cleanDb:done`          | Triggered after indexes deletion.                                | /                                                                                             |
@@ -36,7 +37,7 @@ Events triggered when a database reset is asked to the command-line interface.
 
 Events triggered when a request is treated in the [`collection` controller](/api-reference/#collection-controller).
 
-| Event                       | Description                                                              | Input         |
+| Event                       | Description                                                              | Payload         |
 |-----------------------------|--------------------------------------------------------------------------|---------------|
 | `collection:after<Action>`  | All actions in `collection` controller trigger an event after executing  | Type: Request |
 | `collection:before<Action>` | All actions in `collection` controller trigger an event before executing | Type: Request |
@@ -46,7 +47,7 @@ Events triggered when a request is treated in the [`collection` controller](/api
 
 Events triggered to synchronize Kuzzle server instances in a cluster.
 
-| Event                                   | Description                                                            | Input                |
+| Event                                   | Description                                                            | Payload                |
 |-----------------------------------------|------------------------------------------------------------------------|----------------------|
 | `core:kuzzleStart`                      | Emitted when Kuzzle is started                                         | /                    |
 | `core:hotelClerk:addSubscription`       | Sends a diff containing the filters and internal hotelClerk updates    | hcR object           |
@@ -62,7 +63,7 @@ Events triggered to synchronize Kuzzle server instances in a cluster.
 
 Events triggered when a request is treated in the [`index` controller](/api-reference/#index-controller).
 
-| Event                  | Description                                                         | Input         |
+| Event                  | Description                                                         | Payload         |
 |------------------------|---------------------------------------------------------------------|---------------|
 | `index:after<Action>`  | All actions in `index` controller trigger an event after executing  | Type: Request |
 | `index:before<Action>` | All actions in `index` controller trigger an event before executing | Type: Request |
@@ -72,14 +73,14 @@ Events triggered when a request is treated in the [`index` controller](/api-refe
 
 Events triggered when a request is treated in the [`document` controller](/api-reference/#document-controller).
 
-| Event                     | Description                                                            | Input         |
+| Event                     | Description                                                            | Payload         |
 |---------------------------|------------------------------------------------------------------------|---------------|
 | `document:after<Action>`  | All actions in `document` controller trigger an event after executing  | Type: Request |
 | `document:before<Action>` | All actions in `document` controller trigger an event before executing | Type: Request |
 
 ## http
 
-| Event                     | Description                                                            | Input         |
+| Event                     | Description                                                            | Payload         |
 |---------------------------|------------------------------------------------------------------------|---------------|
 | `http:options` | Triggered whenever a HTTP OPTIONS methods is handled | Type: Request |
 
@@ -89,7 +90,7 @@ Events triggered when a request is treated in the [`document` controller](/api-r
 
 Events triggered by the Kuzzle internal message broker, used to transmit data between Kuzzle instances.
 
-| Event                          | Description                                        | Input                                                |
+| Event                          | Description                                        | Payload                                                |
 |--------------------------------|----------------------------------------------------|------------------------------------------------------|
 | `internalBroker:connected`     | Triggered when the internal broker is connected    | Type: String.<br> `'Connected to Kuzzle server'`     |
 | `internalBroker:error`         | Triggered when an error occured in internal broker | Type: Object.<br> {host, port, message, retry}       |
@@ -102,7 +103,7 @@ Events triggered by the Kuzzle internal message broker, used to transmit data be
 
 Events triggered when a request is sent to the [`memoryStorage` controller](/#memorystorage-controller).
 
-| Event              | Description                                                                 | Input         |
+| Event              | Description                                                                 | Payload         |
 |--------------------|-----------------------------------------------------------------------------|---------------|
 |`ms:after<Action>`  | All actions in `memoryStorage` controller trigger an event after executing  | Type: Request |
 |`ms:before<Action>` | All actions in `memoryStorage` controller trigger an event before executing | Type: Request |
@@ -112,7 +113,7 @@ Events triggered when a request is sent to the [`memoryStorage` controller](/#me
 
 Events triggered during Kuzzle startup, when the database is prepared for Kuzzle's use.
 
-| Event                             | Description                                                                      | Input                                                                                                   |
+| Event                             | Description                                                                      | Payload                                                                                                   |
 |-----------------------------------|----------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
 | `prepareDb:createFixturesIndex`   | Triggered during database preparation. Called for each index in fixtures         | Type: Request.<br> Contains the index to create in `requestObject.index`                                |
 | `prepareDb:createInternalIndex`   | Triggered on Kuzzle start to create the internal index `%kuzzle`                 | Type: Request.<br> Contains the internal index in `requestObject.index`                                 |
@@ -128,7 +129,7 @@ Events triggered during Kuzzle startup, when the database is prepared for Kuzzle
 
 Events triggered when interacting with `proxy`.
 
-| Event                | Description                                                                               | Input                                                                                                                                                                          |
+| Event                | Description                                                                               | Payload                                                                                                                                                                          |
 |----------------------|-------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `proxy:broadcast`    | Triggered before broadcast. You can't modify the input on this event                      | Type: Object.<br> `{payload, channelsList}`<br> `payload` is the notification content. <br>`channelsList` is an array of channels to broadcast.                                |
 | `proxy:joinChannel`  | Triggered after attaching a user to a room. You can't modify the input on this event      | Type: Object.<br> `{channel, id}`<br> `channel` is the channel name.<br> `id` is the connection id                                                                             |
@@ -140,7 +141,7 @@ Events triggered when interacting with `proxy`.
 
 Events triggered when a request is sent to the [`realtime` controller](/api-reference/#realtime-controller).
 
-| Event                    | Description                                                            | Input         |
+| Event                    | Description                                                            | Payload         |
 |--------------------------|------------------------------------------------------------------------|---------------|
 |`realtime:after<Action>`  | All actions in `realtime` controller trigger an event after executing  | Type: Request |
 |`realtime:before<Action>` | All actions in `realtime` controller trigger an event before executing | Type: Request |
@@ -149,7 +150,7 @@ Events triggered when a request is sent to the [`realtime` controller](/api-refe
 
 Events triggered on subscription rooms activity.
 
-| Event         | Description                                                                                    | Input                                                              |
+| Event         | Description                                                                                    | Payload                                                              |
 |---------------|------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
 | `room:new`    | Triggered when a new room is added in the rooms list. You can't modify the input on this event | Type: Object. <br> `{roomId, index, collection, formattedFilters}` |
 | `room:remove` | Triggered after a room is removed from the list. You can't modify the input on this event      | Type: String.<br> The room id                                      |
@@ -159,7 +160,7 @@ Events triggered on subscription rooms activity.
 
 Events triggered when a request is sent to the [`security` controller](/api-reference/#security-controller).
 
-| Event                                 | Description                                                                           | Input         |
+| Event                                 | Description                                                                           | Payload         |
 |---------------------------------------|---------------------------------------------------------------------------------------|---------------|
 | `security:after<Action>`              | All actions in `security` controller trigger an event after executing                 | Type: Request |
 | `security:before<Action>`             | All actions in `security` controller trigger an event before executing                | Type: Request |
@@ -170,7 +171,7 @@ Events triggered when a request is sent to the [`security` controller](/api-refe
 
 Events triggered on server special events or when a request is sent to the [`server` controller](/api-reference/#server-controller).
 
-| Event                   | Description                                                          | Input                                                                 |
+| Event                   | Description                                                          | Payload                                                                 |
 |-------------------------|----------------------------------------------------------------------|-----------------------------------------------------------------------|
 | `server:after<Action>`  | All actions in `server` controller trigger an event after executing  | Type: Request                                                         |
 | `server:before<Action>` | All actions in `server` controller trigger an event before executing | Type: Request                                                         |

--- a/plugin-reference/source/includes/_plugin-context.md
+++ b/plugin-reference/source/includes/_plugin-context.md
@@ -25,7 +25,7 @@ Here is the list of shared objects contained in the provided ``context``:
 ## Accessor
 
 <aside class="notice">
-<a href="#gt-worker-plugins">Worker plugins</a> don't have access to accessors
+<a href="#executing-listeners-in-separate-threads">Plugins that execute on separate threads</a> don't have access to accessors.
 </aside>
 
 ### `execute`

--- a/plugin-reference/source/includes/_plugin-context.md
+++ b/plugin-reference/source/includes/_plugin-context.md
@@ -25,7 +25,7 @@ Here is the list of shared objects contained in the provided ``context``:
 ## Accessor
 
 <aside class="notice">
-<a href="#executing-listeners-in-separate-threads">Plugins that execute on separate threads</a> don't have access to accessors.
+<a href="#executing-listeners-in-separate-threads">Plugins executed on separate threads</a> don't have access to accessors.
 </aside>
 
 ### `execute`

--- a/plugin-reference/source/includes/_plugin-prerequisites.md
+++ b/plugin-reference/source/includes/_plugin-prerequisites.md
@@ -6,42 +6,41 @@ Plugins must be written in Javascript, for the Node.js interpreter. You must be 
 
 As Kuzzle treats plugins as Node.js modules, plugins must make themselves available to Kuzzle using `module.exports`. Otherwise Kuzzle won't be able to instantiate them.
 
-### Plugin default configuration
+Plugins must be valid NodeJS require-able modules, usually shipped as a directory containing either:
 
-Plugins must have a `package.json` file in their root directory, containing a `pluginInfo` entry.
+* an `index.js` file at root, exporting a valid Javascript class exposing an `init` method, or
+* a well-formed `package.json` file at root, specifying the path of the main require-able in the `main` field.
 
-The optional `defaultConfig` attribute is used by Kuzzle to initialize the plugin configuration when installing it.
+To determine the Plugin name, Kuzzle looks for the `name` field in the `package.json` file or the plugin directory name as a fall-back.
 
-This configuration can then be changed using the command-line interface.
+### Custom Plugin configuration
 
-Default configuration example:
+When initializing a Plugin, Kuzzle calls its `init(customConfig, context)` method, passing the [context](/plugin-reference/#the-plugin-context) and the custom configuration. Custom configuration parameters are specified for each plugin in the `plugins` object of the [Kuzzle configuration file](#configuring-kuzzle).
 
 ```json
-"name": "plugin-name",
-"version": "0.0.1",
-"main": "./lib/index.js",
-"pluginInfo": {
-  "defaultConfig": {
-    "any": "information",
-    "useful": ["to", "the", "plugin"]
+{
+  "plugins": {
+    "kuzzle-plugin-blabla": {
+      "option_1": "option_value",
+      "option_2": "option_value"
+    }
   }
 }
 ```
 
-### Special plugin configurations
+Each Plugin is responsible of handling the custom configuration parameters and Kuzzle has no opinion on how to do it. Whether the custom configuration is merged with the defaults or not entirely depends on the implementation of the `init` function.
 
-Additionally to plugins' custom configuration, there are a few reserved words used by Kuzzle to configure how a plugin is loaded:
+Within custom configuration, there are a few reserved words used by Kuzzle to configure how a plugin is loaded:
 
 ```json
-"name": "plugin-name",
-"version": "0.0.1",
-"main": "./lib/index.js",
-"pluginInfo": {
-    "defaultConfig": {
+{
+  "plugins": {
+    "kuzzle-plugin-blabla": {
       "threads": 0,
       "privileged": false
     }
   }
+}
 ```
 
 Where:
@@ -53,14 +52,14 @@ Where:
 
 ### Plugin init function
 
-Plugins must expose a ``init`` function.
+Plugins must expose a `init` function.
 
-Kuzzle calls these ``init`` function at startup, during initialization, and ignore any plugin without this function exposed.
+Kuzzle calls the `init` function at startup, during initialization, and ignores any plugin without this function exposed.
 
 Expected arguments:
-``function (config, context)``
+`function (config, context)`
 
 Where:
 
-* ``config`` (JSON Object): JSON object containing the current plugin configuration
+* ``config`` (JSON Object): JSON object containing the custom plugin configuration
 * ``context`` (JSON Object): the [plugin context](#the-plugin-context)

--- a/plugin-reference/source/includes/_plugin-prerequisites.md
+++ b/plugin-reference/source/includes/_plugin-prerequisites.md
@@ -8,10 +8,10 @@ As Kuzzle treats plugins as Node.js modules, plugins must make themselves availa
 
 Plugins must be valid NodeJS require-able modules, usually shipped as a directory containing either:
 
-* an `index.js` file at root, exporting a valid Javascript class exposing an `init` method, or
-* a well-formed `package.json` file at root, specifying the path of the main require-able in the `main` field.
+* an `index.js` file in its root directory, exporting a valid Javascript class exposing an `init` method, or
+* a well-formed `package.json` file in its root directory, specifying the path of the main require-able in the `main` field.
 
-To determine the Plugin name, Kuzzle looks for the `name` field in the `package.json` file or the plugin directory name as a fall-back.
+To determine the Plugin name, Kuzzle looks for the `name` field in the `package.json` file falling back to the plugin directory name otherwise.
 
 ### Custom Plugin configuration
 
@@ -20,7 +20,7 @@ When initializing a Plugin, Kuzzle calls its `init(customConfig, context)` metho
 ```json
 {
   "plugins": {
-    "kuzzle-plugin-blabla": {
+    "kuzzle-plugin-foobar": {
       "option_1": "option_value",
       "option_2": "option_value"
     }
@@ -35,7 +35,7 @@ Within custom configuration, there are a few reserved words used by Kuzzle to co
 ```json
 {
   "plugins": {
-    "kuzzle-plugin-blabla": {
+    "kuzzle-plugin-foobar": {
       "threads": 0,
       "privileged": false
     }


### PR DESCRIPTION
Fix #81
Documents the new Plugin management system, rewrites the Plugin Types section in the Plugin Reference and does some **boyscouting**

* Fix #72 - links the Events section to the Listener sections
* Fix #55 - fixes a bad URL example in controllers section