### PR TITLE
Use same port for both websocket/socketio/http protocols

### DIFF
--- a/api-reference/source/includes/_authController.md
+++ b/api-reference/source/includes/_authController.md
@@ -5,8 +5,8 @@
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_checkToken`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/_checkToken`
+>**Method:** `POST`
 >**Body:**
 
 <section class="http"></section>
@@ -65,8 +65,8 @@ This API route does not require to be logged in.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/users/_me`  
->**Method:** `GET`  
+>**URL:** `http://kuzzle:7512/users/_me`
+>**Method:** `GET`
 >**Headers:** `Authorization: "Bearer <encrypted_jwt_token>"`
 
 <section class="others"></section>
@@ -120,8 +120,8 @@ Gets the user object identified by the `JSON Web Token` provided in the query or
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/users/_me/_rights`  
->**Method:** `GET`  
+>**URL:** `http://kuzzle:7512/users/_me/_rights`
+>**Method:** `GET`
 >**Headers:** `Authorization: "Bearer <encrypted_jwt_token>"`
 
 <section class="others"></section>
@@ -167,8 +167,8 @@ Gets the rights of the user identified by the `JSON Web Token` provided in the q
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_login`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/_login`
+>**Method:** `POST`
 >**Body:**
 
 <section class="http"></section>
@@ -247,8 +247,8 @@ The **_login** action returns an encrypted JWT token, that must then be sent wit
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_logout`  
->**Method:** `GET`  
+>**URL:** `http://kuzzle:7512/_logout`
+>**Method:** `GET`
 >**Headers:** `Authorization: "Bearer <encrypted_jwt_token>"`
 
 <section class="others"></section>
@@ -290,9 +290,9 @@ The **_logout** action doesn't take strategy.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_updateSelf`  
->**Method:** `PUT`  
->**Headers:** `Authorization: "Bearer <encrypted_jwt_token>"`  
+>**URL:** `http://kuzzle:7512/_updateSelf`
+>**Method:** `PUT`
+>**Headers:** `Authorization: "Bearer <encrypted_jwt_token>"`
 >**Body**
 
 <section class="http"></section>

--- a/api-reference/source/includes/_bulkController.md
+++ b/api-reference/source/includes/_bulkController.md
@@ -21,8 +21,8 @@ even if some of the documents in the import match your subscription filters.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/_bulk`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_bulk`
+>**Method:** `POST`
 >**Body:**
 
 <section class="http"></section>
@@ -115,8 +115,8 @@ In such case, the `collection` in which the documents need to be inserted needs 
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_bulk`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/_bulk`
+>**Method:** `POST`
 >**Body:**
 
 <section class="http"></section>

--- a/api-reference/source/includes/_collectionController.md
+++ b/api-reference/source/includes/_collectionController.md
@@ -5,7 +5,7 @@
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<data>/<collection>`  
+>**URL:** `http://kuzzle:7512/<data>/<collection>`
 >**Method:** `PUT`
 
 <section class="others"></section>
@@ -49,7 +49,7 @@ This method does nothing if the collection already exists.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/_specifications`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_specifications`
 >**Method:** `DELETE`
 
 <section class="others"></section>
@@ -90,7 +90,7 @@ It responds 200 even there where no validation specification manually set before
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/_exists`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_exists`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -130,7 +130,7 @@ Checks if a collection exists in Kuzzle database storage layer.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/_mapping`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_mapping`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -185,8 +185,8 @@ Gets the mapping of the given `collection`.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/_specifications`  
->**Method:** `GET`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_specifications`
+>**Method:** `GET`
 
 <section class="others"></section>
 
@@ -254,7 +254,7 @@ index and collection if some specifications has been defined first.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/_list(/<all|stored|realtime>)[?from=0][&size=42]`  
+>**URL:** `http://kuzzle:7512/<index>/_list(/<all|stored|realtime>)[?from=0][&size=42]`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -327,8 +327,8 @@ The `from` and `size` arguments allow pagination. They are returned in the respo
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_searchSpecifications`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/_searchSpecifications`
+>**Method:** `POST`
 >**Body**
 
 <section class="http"></section>
@@ -383,34 +383,34 @@ The `from` and `size` arguments allow pagination. They are returned in the respo
     },
     "hits": [
       {
-        "_id": "myIndex#myCollection", 
-        "_index": "%kuzzle", 
-        "_score": 1, 
+        "_id": "myIndex#myCollection",
+        "_index": "%kuzzle",
+        "_score": 1,
         "_source": {
-          "collection": "myCollection", 
-          "index": "myIndex", 
+          "collection": "myCollection",
+          "index": "myIndex",
           "validation": {
             "fields": {
               "fieldName": {
-                "defaultValue": "a default value", 
-                "mandatory": true, 
+                "defaultValue": "a default value",
+                "mandatory": true,
                 "multivalued": {
-                  "maxCount": 5, 
-                  "minCount": 1, 
+                  "maxCount": 5,
+                  "minCount": 1,
                   "value": true
-                }, 
-                "type": "string", 
+                },
+                "type": "string",
                 "typeOptions": {
                   "length": {
-                    "max": 12, 
+                    "max": 12,
                     "min": 2
                   }
                 }
               }
-            }, 
+            },
             "strict": true
           }
-        }, 
+        },
         "_type": "validations"
       }
     ],
@@ -429,7 +429,7 @@ Allows to search in the persistence layer for collection specifications.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/_truncate`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_truncate`
 >**Method:** `DELETE`
 
 <section class="others"></section>
@@ -472,8 +472,8 @@ It is also faster than deleting all documents from a collection using a query.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/_mapping`  
->**Method:** `PUT`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_mapping`
+>**Method:** `PUT`
 >**Body:**
 
 <section class="http"></section>
@@ -563,8 +563,8 @@ To solve this matter, Kuzzle's API offers a way to create data mapping and to ex
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_specifications`  
->**Method:** `PUT`  
+>**URL:** `http://kuzzle:7512/_specifications`
+>**Method:** `PUT`
 >**Body:**
 
 <section class="http"></section>
@@ -668,8 +668,8 @@ When the validation specification is not well formatted, a detailed error messag
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_validateSpecifications`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/_validateSpecifications`
+>**Method:** `POST`
 >**Body:**
 
 <section class="http"></section>

--- a/api-reference/source/includes/_connectToKuzzle.md
+++ b/api-reference/source/includes/_connectToKuzzle.md
@@ -15,11 +15,11 @@ Other protocols can be added with [Protocol Plugins](/plugin-reference/#protocol
 <section class="http"></section>
 
 ```bash
- $ curl "http://localhost:7511/"
+ $ curl "http://localhost:7512/"
 ```
 
-By default, Kuzzle exposes itself on the 7511 port. Assuming the Kuzzle server runs locally,
-it can be reached on `http://localhost:7511/`.
+By default, Kuzzle exposes itself on the 7512 port. Assuming the Kuzzle server runs locally,
+it can be reached on `http://localhost:7512/`.
 
 The default response is the [ServerInfo](?http#serverinfo) controller.
 With this you will get detailed information about available HTTP API routes.
@@ -35,12 +35,12 @@ With this you will get detailed information about available HTTP API routes.
 
 ```html
 <script>
-    var socket = new WebSocket("ws://localhost:7511");
+    var socket = new WebSocket("ws://localhost:7512");
 </script>
 ```
 
 By default, Kuzzle enables the core websockets protocol,
-accepting websocket requests via the http server (on port 7511 by default).
+accepting websocket requests via the http server (on port 7512 by default).
 
 
 ## Socket.io (WebSocket-like)
@@ -54,12 +54,12 @@ accepting websocket requests via the http server (on port 7511 by default).
 ```html
 <script src="https://cdn.socket.io/socket.io-1.4.5.js"></script>
 <script>
-    var socket = io("http://localhost:7511");
+    var socket = io("http://localhost:7512");
 </script>
 ```
 
 To ensure compatibility with older web browsers, our official docker images embeds the
-Kuzzle embeds a socketio protocol, accepting socket requests via the http server (on port 7511 by default).
+Kuzzle embeds a socketio protocol, accepting socket requests via the http server (on port 7512 by default).
 
 
 

--- a/api-reference/source/includes/_connectToKuzzle.md
+++ b/api-reference/source/includes/_connectToKuzzle.md
@@ -6,6 +6,9 @@ title: Connecting to Kuzzle
 
 The connection to Kuzzle depends on the protocol to be used.
 
+Both HTTP, WebSocket and SocketIO protocols are shipped in Kuzzle's core.
+Other protocols can be added with [Protocol Plugins](/plugin-reference/#protocol-plugins).
+
 
 ## HTTP
 
@@ -17,7 +20,6 @@ The connection to Kuzzle depends on the protocol to be used.
 
 By default, Kuzzle exposes itself on the 7511 port. Assuming the Kuzzle server runs locally,
 it can be reached on `http://localhost:7511/`.
-Note that HTTP is the only protocol shipped in Kuzzle's core.
 
 The default response is the [ServerInfo](?http#serverinfo) controller.
 With this you will get detailed information about available HTTP API routes.
@@ -33,12 +35,12 @@ With this you will get detailed information about available HTTP API routes.
 
 ```html
 <script>
-    var socket = new WebSocket("ws://localhost:7513");
+    var socket = new WebSocket("ws://localhost:7511");
 </script>
 ```
 
-By default, Kuzzle embarks our official [WebSocket](https://www.npmjs.com/package/kuzzle-plugin-websocket) plugin,
-accepting websocket requests on the 7513 port.
+By default, Kuzzle enables the core websockets protocol,
+accepting websocket requests via the http server (on port 7511 by default).
 
 
 ## Socket.io (WebSocket-like)
@@ -52,14 +54,13 @@ accepting websocket requests on the 7513 port.
 ```html
 <script src="https://cdn.socket.io/socket.io-1.4.5.js"></script>
 <script>
-    var socket = io("http://localhost:7512");
+    var socket = io("http://localhost:7511");
 </script>
 ```
 
 To ensure compatibility with older web browsers, our official docker images embeds the
-[Socket.io](https://www.npmjs.com/package/kuzzle-plugin-socketio) protocol plugin.
+Kuzzle embeds a socketio protocol, accepting socket requests via the http server (on port 7511 by default).
 
-By default, this plugin listens to the port 7512.
 
 
 ## MQTT protocols

--- a/api-reference/source/includes/_connectToKuzzle.md
+++ b/api-reference/source/includes/_connectToKuzzle.md
@@ -6,7 +6,7 @@ title: Connecting to Kuzzle
 
 The connection to Kuzzle depends on the protocol to be used.
 
-Both HTTP, WebSocket and SocketIO protocols are shipped in Kuzzle's core.
+HTTP, WebSocket and SocketIO protocols are shipped in Kuzzle's core.
 Other protocols can be added with [Protocol Plugins](/plugin-reference/#protocol-plugins).
 
 

--- a/api-reference/source/includes/_documentController.md
+++ b/api-reference/source/includes/_documentController.md
@@ -5,8 +5,8 @@
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/_count`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_count`
+>**Method:** `POST`
 >**Body:**
 
 <section class="http"></section>
@@ -70,8 +70,8 @@ Kuzzle uses the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasti
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/_create[?refresh=wait_for]` or `http://kuzzle:7511/<index>/<collection>/<documentId>/_create[?refresh=wait_for]`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_create[?refresh=wait_for]` or `http://kuzzle:7512/<index>/<collection>/<documentId>/_create[?refresh=wait_for]`
+>**Method:** `POST`
 >**Body:**
 
 <section class="http"></section>
@@ -135,8 +135,8 @@ with the value `wait_for` in order to wait for the document indexation (indexed 
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/<documentId>[?refresh=wait_for]`  
->**Method:** `PUT`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/<documentId>[?refresh=wait_for]`
+>**Method:** `PUT`
 >**Body:**
 
 <section class="http"></section>
@@ -200,7 +200,7 @@ with the value `wait_for` in order to wait for the document indexation (indexed 
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/<documentId>[?refresh=wait_for]`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/<documentId>[?refresh=wait_for]`
 >**Method:** `DELETE`
 
 <section class="others"></section>
@@ -252,8 +252,8 @@ with the value `wait_for` in order to wait for the document deletion (and its un
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/_query`  
->**Method:** `DELETE`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_query`
+>**Method:** `DELETE`
 >**Body:**
 
 <section class="http"></section>
@@ -318,7 +318,7 @@ Kuzzle uses the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasti
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/<documentId>`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/<documentId>`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -377,8 +377,8 @@ Only documents in the persistent data storage layer can be retrieved.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/<documentId>/_replace[?refresh=wait_for]`  
->**Method:** `PUT`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/<documentId>/_replace[?refresh=wait_for]`
+>**Method:** `PUT`
 >**Body:**
 
 <section class="http"></section>
@@ -442,8 +442,8 @@ with the value `wait_for` in order to wait for the document indexation (indexed 
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_scroll/<scrollId>`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/_scroll/<scrollId>`
+>**Method:** `POST`
 >**Body:**
 
 <section class="http"></section>
@@ -527,8 +527,8 @@ which tells Elasticsearch how long it should keep the “search context” alive
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/_search[?from=0][&size=42]`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_search[?from=0][&size=42]`
+>**Method:** `POST`
 >**Body:**
 
 <section class="http"></section>
@@ -626,8 +626,8 @@ for more details.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/_mCreate[?refresh=wait_for]`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_mCreate[?refresh=wait_for]`
+>**Method:** `POST`
 >**Body:**
 
 <section class="http"></section>
@@ -770,8 +770,8 @@ with the value `wait_for` in order to wait for the document indexation (indexed 
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/_mCreateOrReplace[?refresh=wait_for]`  
->**Method:** `PUT`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_mCreateOrReplace[?refresh=wait_for]`
+>**Method:** `PUT`
 >**Body:**
 
 <section class="http"></section>
@@ -895,7 +895,7 @@ with the value `wait_for` in order to wait for the document indexation (indexed 
         "result": "updated"
       },
       {
-        // Other created or replaced documents 
+        // Other created or replaced documents
       }
     ],
     "total": <number of created or replaced documents>
@@ -912,8 +912,8 @@ Returns a partial error (with status 206) if one or more documents can not be cr
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/_mDelete[?refresh=wait_for]`  
->**Method:** `DELETE`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_mDelete[?refresh=wait_for]`
+>**Method:** `DELETE`
 >**Body:**
 
 <section class="http"></section>
@@ -974,8 +974,8 @@ with the value `wait_for` in order to wait for the document indexation (indexed 
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/_mGet`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_mGet`
+>**Method:** `POST`
 >**Body:**
 
 <section class="http"></section>
@@ -1054,7 +1054,7 @@ with the value `wait_for` in order to wait for the document indexation (indexed 
         "found": true
       }
       {
-        // Other documents 
+        // Other documents
       }
     ],
     "total": <number of retrieved documents>
@@ -1071,8 +1071,8 @@ Only documents in the persistent data storage layer can be retrieved.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/_mReplace[?refresh=wait_for]`  
->**Method:** `PUT`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_mReplace[?refresh=wait_for]`
+>**Method:** `PUT`
 >**Body:**
 
 <section class="http"></section>
@@ -1196,7 +1196,7 @@ Only documents in the persistent data storage layer can be retrieved.
         "result": "updated"
       },
       {
-        // Other replaced documents 
+        // Other replaced documents
       }
     ],
     "total": <number of replaced documents>
@@ -1216,8 +1216,8 @@ with the value `wait_for` in order to wait for the document indexation (indexed 
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/_mUpdate[?refresh=wait_for]`  
->**Method:** `PUT`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_mUpdate[?refresh=wait_for]`
+>**Method:** `PUT`
 >**Body:**
 
 <section class="http"></section>
@@ -1337,8 +1337,8 @@ with the value `wait_for` in order to wait for the document indexation (indexed 
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/<documentId>/_update[?refresh=wait_for]`  
->**Method:** `PUT`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/<documentId>/_update[?refresh=wait_for]`
+>**Method:** `PUT`
 >**Body:**
 
 <section class="http"></section>
@@ -1406,8 +1406,8 @@ with the value `wait_for` in order to wait for the document indexation (indexed 
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/_validate`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_validate`
+>**Method:** `POST`
 >**Body:**
 
 <section class="http"></section>

--- a/api-reference/source/includes/_indexController.md
+++ b/api-reference/source/includes/_indexController.md
@@ -5,7 +5,7 @@
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>`  
+>**URL:** `http://kuzzle:7512/<index>`
 >**Method:** `POST`
 
 <section class="others"></section>
@@ -48,7 +48,7 @@ Create an `index` in Kuzzle's persistent storage layer.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>`  
+>**URL:** `http://kuzzle:7512/<index>`
 >**Method:** `DELETE`
 
 <section class="others"></section>
@@ -88,7 +88,7 @@ Deletes an entire `index` from Kuzzle's persistent storage layer.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/_exists`  
+>**URL:** `http://kuzzle:7512/<index>/_exists`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -126,7 +126,7 @@ Checks if the given index exists in Kuzzle storage layer.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/_autoRefresh`  
+>**URL:** `http://kuzzle:7512/<index>/_autoRefresh`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -178,7 +178,7 @@ The `getAutoRefresh` actions returns the current `autoRefresh` status for the gi
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_list`  
+>**URL:** `http://kuzzle:7512/_list`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -222,8 +222,8 @@ Returns the complete data indexes.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_mDelete`  
->**Method:** `DELETE`  
+>**URL:** `http://kuzzle:7512/_mDelete`
+>**Method:** `DELETE`
 >**Body:**
 
 <section class="http"></section>
@@ -289,7 +289,7 @@ The response contains the list of indexes that were actually deleted.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/_refresh`  
+>**URL:** `http://kuzzle:7512/<index>/_refresh`
 >**Method:** `POST`
 
 <section class="others"></section>
@@ -355,7 +355,7 @@ on it, making the documents visible to search immediately.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_refreshInternal`  
+>**URL:** `http://kuzzle:7512/_refreshInternal`
 >**Method:** `POST`
 
 <section class="others"></section>
@@ -415,7 +415,7 @@ on the internal index, making the documents visible to search immediately.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/_autoRefresh`  
+>**URL:** `http://kuzzle:7512/<index>/_autoRefresh`
 >**Method:** `POST`
 
 >Query

--- a/api-reference/source/includes/_memorystorageController.md
+++ b/api-reference/source/includes/_memorystorageController.md
@@ -5,7 +5,7 @@
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/ms/_ping`  
+>**URL:** `http://kuzzle:7512/ms/_ping`
 >**Method:** `GET`
 
 <section class="others"></section>

--- a/api-reference/source/includes/_notifications.md
+++ b/api-reference/source/includes/_notifications.md
@@ -10,7 +10,7 @@
 // For browsers not supporting websocket, use socket.io instead
 <script>
   var
-    socket = new WebSocket("ws://localhost:7513"),
+    socket = new WebSocket("ws://localhost:7511"),
     channel;
 
   socket.onmessage = function (payload) {
@@ -79,7 +79,7 @@
 ```html
 <script src="https://cdn.socket.io/socket.io-1.4.5.js"></script>
 <script>
-  var socket = io("http://localhost:7512");
+  var socket = io("http://localhost:7511");
 
   // step 1 - we prepare ourself to receive Kuzzle's subscription response and then listen to the created channel.
   socket.once("mySubscription", function (response) {

--- a/api-reference/source/includes/_notifications.md
+++ b/api-reference/source/includes/_notifications.md
@@ -10,7 +10,7 @@
 // For browsers not supporting websocket, use socket.io instead
 <script>
   var
-    socket = new WebSocket("ws://localhost:7511"),
+    socket = new WebSocket("ws://localhost:7512"),
     channel;
 
   socket.onmessage = function (payload) {
@@ -79,7 +79,7 @@
 ```html
 <script src="https://cdn.socket.io/socket.io-1.4.5.js"></script>
 <script>
-  var socket = io("http://localhost:7511");
+  var socket = io("http://localhost:7512");
 
   // step 1 - we prepare ourself to receive Kuzzle's subscription response and then listen to the created channel.
   socket.once("mySubscription", function (response) {

--- a/api-reference/source/includes/_querySyntax.md
+++ b/api-reference/source/includes/_querySyntax.md
@@ -11,8 +11,8 @@ Please refer to the code samples on the right pane for more detail on the specif
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<action route>[route options]`  
->**Method:** `get|post|put|delete`  
+>**URL:** `http://kuzzle:7512/<action route>[route options]`
+>**Method:** `get|post|put|delete`
 >**Body:** Can be empty (usually with get and delete methods) or a JSON object
 of the resource body (usually with post and put methods).
 
@@ -109,7 +109,7 @@ identify which query generated the response you got, the best way is to provide 
 <section class="http"></section>
 
 ```bash
- $ curl -H "Authorization: Bearer <encrypted_jwt_token>" "http://localhost:7511/..."
+ $ curl -H "Authorization: Bearer <encrypted_jwt_token>" "http://localhost:7512/..."
 ```
 
 <section class="others"></section>

--- a/api-reference/source/includes/_realtimeController.md
+++ b/api-reference/source/includes/_realtimeController.md
@@ -329,7 +329,7 @@ who have subscribed to a subscription for which the filters match the message co
 ```html
 <script>
   var
-    socket = new WebSocket("ws://localhost:7513"),
+    socket = new WebSocket("ws://localhost:7511"),
     channel;
 
   socket.onmessage = function (payload) {
@@ -388,7 +388,7 @@ who have subscribed to a subscription for which the filters match the message co
  */
 <script src="https://cdn.socket.io/socket.io-1.4.5.js"></script>
 <script>
-    var socket = io("http://localhost:7512");
+    var socket = io("http://localhost:7511");
 
     socket.once("mySubscription", function (response) {
       console.log(response);

--- a/api-reference/source/includes/_realtimeController.md
+++ b/api-reference/source/includes/_realtimeController.md
@@ -116,7 +116,7 @@ The `roomId` parameter is returned by Kuzzle when [subscribing](#subscribe) to s
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_listSubscriptions`  
+>**URL:** `http://kuzzle:7512/_listSubscriptions`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -172,8 +172,8 @@ Lists all subscriptions on all indexes and all collections.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/_publish`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_publish`
+>**Method:** `POST`
 >**Body:**
 
 <section class="http"></section>
@@ -329,7 +329,7 @@ who have subscribed to a subscription for which the filters match the message co
 ```html
 <script>
   var
-    socket = new WebSocket("ws://localhost:7511"),
+    socket = new WebSocket("ws://localhost:7512"),
     channel;
 
   socket.onmessage = function (payload) {
@@ -388,7 +388,7 @@ who have subscribed to a subscription for which the filters match the message co
  */
 <script src="https://cdn.socket.io/socket.io-1.4.5.js"></script>
 <script>
-    var socket = io("http://localhost:7511");
+    var socket = io("http://localhost:7512");
 
     socket.once("mySubscription", function (response) {
       console.log(response);
@@ -513,8 +513,8 @@ The expected parameter is the `roomId` that Kuzzle returned during the subscript
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<index>/<collection>/_validate`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_validate`
+>**Method:** `POST`
 >**Body:**
 
 <section class="http"></section>

--- a/api-reference/source/includes/_securityController.md
+++ b/api-reference/source/includes/_securityController.md
@@ -5,8 +5,8 @@
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/<userId>/_createFirstAdmin[?reset=1]` or `http://kuzzle:7511/_createFirstAdmin[?reset=1]`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/<userId>/_createFirstAdmin[?reset=1]` or `http://kuzzle:7512/_createFirstAdmin[?reset=1]`
+>**Method:** `POST`
 >**Body**
 
 <section class="http"></section>
@@ -101,8 +101,8 @@ Other mandatory additional information are needed depending on the authenticatio
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/profiles/<profileId>`  
->**Method:** `PUT`  
+>**URL:** `http://kuzzle:7512/profiles/<profileId>`
+>**Method:** `PUT`
 >**Body**
 
 <section class="http"></section>
@@ -201,8 +201,8 @@ Creates (if no `_id` provided) or updates (if `_id` matches an existing one) a p
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/roles/<roleId>`  
->**Method:** `PUT`  
+>**URL:** `http://kuzzle:7512/roles/<roleId>`
+>**Method:** `PUT`
 >**Body**
 
 <section class="http"></section>
@@ -287,8 +287,8 @@ please refer to [Kuzzle's security documentation](https://github.com/kuzzleio/ku
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/users/<userId>`  
->**Method:** `PUT`  
+>**URL:** `http://kuzzle:7512/users/<userId>`
+>**Method:** `PUT`
 >**Body**
 
 <section class="http"></section>
@@ -356,8 +356,8 @@ The `user` is created if it does not exists yet or replaced with the given objec
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/profiles/<profileId>/_create`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/profiles/<profileId>/_create`
+>**Method:** `POST`
 >**Body**
 
 <section class="http"></section>
@@ -459,8 +459,8 @@ Creates a profile with a new list of roles.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/roles/<roleId>/_create`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/roles/<roleId>/_create`
+>**Method:** `POST`
 >**Body**
 
 <section class="http"></section>
@@ -546,8 +546,8 @@ please refer to [Kuzzle's security documentation](https://github.com/kuzzleio/ku
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/users/<userId>/_create` or `http://kuzzle:7511/users/_create`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/users/<userId>/_create` or `http://kuzzle:7512/users/_create`
+>**Method:** `POST`
 >**Body**
 
 <section class="http"></section>
@@ -645,8 +645,8 @@ Other mandatory additional information are needed depending on the authenticatio
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/users/<userId>/_createRestricted` or `http://kuzzle:7511/users/_createRestricted`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/users/<userId>/_createRestricted` or `http://kuzzle:7512/users/_createRestricted`
+>**Method:** `POST`
 >**Body**
 
 <section class="http"></section>
@@ -739,7 +739,7 @@ Other mandatory additional information are needed depending on the authenticatio
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_profiles/<profileId>`  
+>**URL:** `http://kuzzle:7512/_profiles/<profileId>`
 >**Method:** `DELETE`
 
 <section class="others"></section>
@@ -784,7 +784,7 @@ that the related roles will NOT be deleted.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/roles/<roleId>`  
+>**URL:** `http://kuzzle:7512/roles/<roleId>`
 >**Method:** `DELETE`
 
 <section class="others"></section>
@@ -828,7 +828,7 @@ Given a `role id`, deletes the corresponding role from the database.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/users/<userId>`  
+>**URL:** `http://kuzzle:7512/users/<userId>`
 >**Method:** `DELETE`
 
 <section class="others"></section>
@@ -872,7 +872,7 @@ Given a `user id`, deletes the corresponding `user` from Kuzzle's database layer
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_profiles/<profileId>`  
+>**URL:** `http://kuzzle:7512/_profiles/<profileId>`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -919,7 +919,7 @@ Given a `profile id`, retrieves the corresponding profile from the database.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/profiles/_mapping`  
+>**URL:** `http://kuzzle:7512/profiles/_mapping`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -999,7 +999,7 @@ Gets the mapping of the internal `profiles` collection.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_profiles/<profileId>/_rights`  
+>**URL:** `http://kuzzle:7512/_profiles/<profileId>/_rights`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -1048,7 +1048,7 @@ Given a `profile id`, retrieves the corresponding rights.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/roles/<role id>`  
+>**URL:** `http://kuzzle:7512/roles/<role id>`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -1098,7 +1098,7 @@ Given a `role id`, retrieves the corresponding role from the database.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/roles/_mapping`  
+>**URL:** `http://kuzzle:7512/roles/_mapping`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -1141,7 +1141,7 @@ Gets the mapping of the internal `roles` collection.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/users/<userId>`  
+>**URL:** `http://kuzzle:7512/users/<userId>`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -1187,7 +1187,7 @@ Given a `user id`, gets the matching user from Kuzzle's dabatase layer.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/users/_mapping`  
+>**URL:** `http://kuzzle:7512/users/_mapping`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -1273,7 +1273,7 @@ Gets the mapping of the internal `users` collection.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_users/<userId>/_rights`  
+>**URL:** `http://kuzzle:7512/_users/<userId>/_rights`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -1319,8 +1319,8 @@ Given a `user id`, gets the matching user's rights from Kuzzle's dabatase layer.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/profiles/_mdelete`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/profiles/_mdelete`
+>**Method:** `POST`
 >**Body:**
 
 <section class="http"></section>
@@ -1371,8 +1371,8 @@ Deletes a list of `profile` objects from Kuzzle's database layer given a list of
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/roles/_mdelete`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/roles/_mdelete`
+>**Method:** `POST`
 >**Body:**
 
 <section class="http"></section>
@@ -1423,8 +1423,8 @@ Deletes a list of `roles` objects from Kuzzle's database layer given a list of r
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/users/_mdelete`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/users/_mdelete`
+>**Method:** `POST`
 >**Body:**
 
 <section class="http"></section>
@@ -1476,8 +1476,8 @@ Deletes a list of `users` objects from Kuzzle's database layer given a list of u
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/profiles/_mGet`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/profiles/_mGet`
+>**Method:** `POST`
 >**Body:**
 
 <section class="http"></section>
@@ -1532,8 +1532,8 @@ Retrieves a list of `profile` objects from Kuzzle's database layer given a list 
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/roles/_mGet`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/roles/_mGet`
+>**Method:** `POST`
 >**Body:**
 
 <section class="http"></section>
@@ -1608,8 +1608,8 @@ Retrieves a list of `role` objects from Kuzzle's database layer given a list of 
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/profiles/_search[?from=0][&size=42]`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/profiles/_search[?from=0][&size=42]`
+>**Method:** `POST`
 >**Body**
 
 <section class="http"></section>
@@ -1709,8 +1709,8 @@ Available filters:
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/roles/_search[?from=0][&size=42]`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/roles/_search[?from=0][&size=42]`
+>**Method:** `POST`
 >**Body:**
 
 <section class="http"></section>
@@ -1797,8 +1797,8 @@ Available filters:
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/users/_search[?from=0][&size=42]`  
->**Method:** `POST`  
+>**URL:** `http://kuzzle:7512/users/_search[?from=0][&size=42]`
+>**Method:** `POST`
 >**Body**
 
 <section class="http"></section>
@@ -1901,8 +1901,8 @@ The `from` and `size` arguments allow pagination.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/profiles/<profile id>/_update`  
->**Method:** `PUT`  
+>**URL:** `http://kuzzle:7512/profiles/<profile id>/_update`
+>**Method:** `PUT`
 >**Body**
 
 <section class="http"></section>
@@ -1997,7 +1997,7 @@ Given a `profile id`, updates the matching Profile object in Kuzzle's database l
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/profiles/_mapping`
+>**URL:** `http://kuzzle:7512/profiles/_mapping`
 >**Method:** `PUT`
 >**Body:**
 
@@ -2083,8 +2083,8 @@ But if you want to store more information about your users, Kuzzle's API offers 
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/roles/<roleId>/_update`  
->**Method:** `PUT`  
+>**URL:** `http://kuzzle:7512/roles/<roleId>/_update`
+>**Method:** `PUT`
 >**Body**
 
 <section class="http"></section>
@@ -2163,7 +2163,7 @@ please refer to [Kuzzle's security documentation](https://github.com/kuzzleio/ku
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/roles/_mapping`
+>**URL:** `http://kuzzle:7512/roles/_mapping`
 >**Method:** `PUT`
 >**Body:**
 
@@ -2249,8 +2249,8 @@ But if you want to store more information about your users, Kuzzle's API offers 
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/users/<userId>/_update`  
->**Method:** `PUT`  
+>**URL:** `http://kuzzle:7512/users/<userId>/_update`
+>**Method:** `PUT`
 >**Body**
 
 <section class="http"></section>
@@ -2309,7 +2309,7 @@ Given a `user id`, updates the matching User object in Kuzzle's database layer.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/users/_mapping`
+>**URL:** `http://kuzzle:7512/users/_mapping`
 >**Method:** `PUT`
 >**Body:**
 

--- a/api-reference/source/includes/_serverController.md
+++ b/api-reference/source/includes/_serverController.md
@@ -5,7 +5,7 @@
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_adminExists`  
+>**URL:** `http://kuzzle:7512/_adminExists`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -44,7 +44,7 @@ Checks if an administrator account has been created, and return a boolean as a r
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_getAllStats`  
+>**URL:** `http://kuzzle:7512/_getAllStats`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -114,7 +114,7 @@ Statistics are returned as a JSON-object with each key being the snapshot's time
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_getConfig`  
+>**URL:** `http://kuzzle:7512/_getConfig`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -419,7 +419,7 @@ Returns the current Kuzzle configuration as loaded at Kuzzle start.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_getLastStats`  
+>**URL:** `http://kuzzle:7512/_getLastStats`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -483,7 +483,7 @@ Statistics are returned as a JSON-object with each key being the snapshot's time
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_getStats[?startTime=123456789][&stopTime=234567890]`  
+>**URL:** `http://kuzzle:7512/_getStats[?startTime=123456789][&stopTime=234567890]`
 >**Method:** `POST`
 
 <section class="others"></section>
@@ -557,7 +557,7 @@ Statistics are returned as a JSON-object with each key being the snapshot's time
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_serverInfo`  
+>**URL:** `http://kuzzle:7512/_serverInfo`
 >**Method:** `GET`
 
 <section class="others"></section>
@@ -681,7 +681,7 @@ Retrieves information about Kuzzle, its plugins and active services.
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7511/_now`  
+>**URL:** `http://kuzzle:7512/_now`
 >**Method:** `GET`
 
 <section class="others"></section>

--- a/guide/source/includes/advanced/_request-scenarios.md
+++ b/guide/source/includes/advanced/_request-scenarios.md
@@ -16,7 +16,7 @@ The following diagram shows how the Request flows between the client application
 
 ![read_scenario_http_details](./images/request-scenarios/read-http/details.png)
 
-* The HTTP client asks for a document via a HTTP GET Request. For instance, to retrieve the document '739c26bc-7a09-469a-803d-623c4045b0cb' in the collection `users`: `GET http://kuzzle:7511/mainindex/users/739c26bc-7a09-469a-803d-623c4045b0cb`.
+* The HTTP client asks for a document via a HTTP GET Request. For instance, to retrieve the document '739c26bc-7a09-469a-803d-623c4045b0cb' in the collection `users`: `GET http://kuzzle:7512/mainindex/users/739c26bc-7a09-469a-803d-623c4045b0cb`.
 * The proxy forwards the Request through the HTTP Entry point to the Router, which handles it and forwards the formatted Request to the Funnel.
 
 The formatted Request `input` looks like the following:

--- a/guide/source/includes/essentials/_configuration.md
+++ b/guide/source/includes/essentials/_configuration.md
@@ -45,7 +45,7 @@ services:
   proxy:
     image: kuzzleio/proxy
     ports:
-      - "7511-7513:7511-7513"
+      - "7512:7512"
 
   kuzzle:
     image: kuzzleio/kuzzle

--- a/guide/source/includes/essentials/_installation-linux.md
+++ b/guide/source/includes/essentials/_installation-linux.md
@@ -32,10 +32,10 @@ Your terminal will show the log messages of Kuzzle's components starting. After 
 kuzzle_1         | [✔] Kuzzle server ready
 ```
 
-Your Kuzzle server is now ready to be used. For instance, you can hit the main HTTP API endpoint by browsing the page <a href="http://localhost:7511">http://localhost:7511</a> or via cURL on the command line:
+Your Kuzzle server is now ready to be used. For instance, you can hit the main HTTP API endpoint by browsing the page <a href="http://localhost:7512">http://localhost:7512</a> or via cURL on the command line:
 
 ```bash
-$ curl "http://localhost:7511/?pretty"
+$ curl "http://localhost:7512/?pretty"
 ```
 
 Kuzzle will respond you with a list of the existing routes.
@@ -131,8 +131,8 @@ kuzzle_1         | [✔] Kuzzle server ready
 ```
 
 The Kuzzle Back-office can be reached on http://localhost:3000.  
-Kuzzle HTTP API can be reached on http://localhost:7511/  
-Socket IO and Websocket channels can be reached over the HTTP server, on port 7511.
+Kuzzle HTTP API can be reached on http://localhost:7512/  
+Socket IO and Websocket channels can be reached over the HTTP server, on port 7512.
 
 ##### Change external services hosts or ports
 
@@ -155,7 +155,7 @@ Having trouble? <a href="https://gitter.im/kuzzleio/kuzzle-bo">Get in touch with
 
 ### Select the Kuzzle server to connect to
 
-The Kuzzle Backoffice automatically looks for a Kuzzle server on `localhost:7513`. If none is present, you will be prompted to choose a Kuzzle instance to connect to.
+The Kuzzle Backoffice automatically looks for a Kuzzle server on `localhost:7512`. If none is present, you will be prompted to choose a Kuzzle instance to connect to.
 
 You can tell the Backoffice to connect to any Kuzzle server by clicking on the **"Choose Environment"** dropdown menu, then by selecting **"Create new"**.
 

--- a/guide/source/includes/essentials/_installation-linux.md
+++ b/guide/source/includes/essentials/_installation-linux.md
@@ -132,7 +132,7 @@ kuzzle_1         | [✔] Kuzzle server ready
 
 The Kuzzle Back-office can be reached on http://localhost:3000.  
 Kuzzle HTTP API can be reached on http://localhost:7511/  
-Socket IO and Websocket channels can respectively be reached on ports 7512 and 7513.
+Socket IO and Websocket channels can be reached over the HTTP server, on port 7511.
 
 ##### Change external services hosts or ports
 

--- a/guide/source/includes/essentials/_persisted.md
+++ b/guide/source/includes/essentials/_persisted.md
@@ -12,7 +12,7 @@ In Kuzzle, data is organized in the following way:
 
 Kuzzle ships with a full data [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) API that enables you to operate in many ways on your documents.
 
-Let's [**create a new document**](/api-reference/#create48), for example, in `mycollection`, within `myindex` via the HTTP protocol. This is done by sending a `POST` request to the API endpoint `http://localhost:7511/myindex/mycollection/_create` with the body set to
+Let's [**create a new document**](/api-reference/#create48), for example, in `mycollection`, within `myindex` via the HTTP protocol. This is done by sending a `POST` request to the API endpoint `http://localhost:7512/myindex/mycollection/_create` with the body set to
 
 ```json
 {
@@ -62,7 +62,7 @@ Notice that the document is associated to the auto-generated id `AVkDBl3YsT6qHI7
 
 Take some time to examine the content of a [Kuzzle Response](#kuzzle-response-objects). You may notice that it contains useful information like the name of the [controller and action](/#core-architecture) that correspond to the HTTP route we hit with our request, or the complete KuzzleDocument object we just created.
 
-One more thing you may notice is that `myindex` and `mycollection` are created on-the-fly along with the document. Let's verify it by [**getting the list of collections**](/api-reference/?http#list) stored in `myindex` by sending a `GET` request to `http://localhost:7511/myindex/_list`.
+One more thing you may notice is that `myindex` and `mycollection` are created on-the-fly along with the document. Let's verify it by [**getting the list of collections**](/api-reference/?http#list) stored in `myindex` by sending a `GET` request to `http://localhost:7512/myindex/_list`.
 
 ```json
 {
@@ -89,7 +89,7 @@ One more thing you may notice is that `myindex` and `mycollection` are created o
 
 Take a look at the `result` field in the Response from Kuzzle. It contains an array of `collections`, each one defined by a `name` and a `type`. `mycollection` is of type `stored` (which stands for persistent). This is made to distinguish persisted collection from the `realtime` (or volatile) collections, used to identify [real-time documents](#realtime-notifications).
 
-Let's [**modify to our brand new document**](/api-reference/?http#update) by sending a `PUT` request to `http://localhost:7511/myindex/mycollection/AVkDBl3YsT6qHI7MxLz0/_update` with the body set to:
+Let's [**modify to our brand new document**](/api-reference/?http#update) by sending a `PUT` request to `http://localhost:7512/myindex/mycollection/AVkDBl3YsT6qHI7MxLz0/_update` with the body set to:
 
 ```json
 {
@@ -128,13 +128,13 @@ Which gives us the response...
 
 ...telling us that the document has been successfully updated.
 
-Now, we'll let you figure out what happens when we send a `DELETE` request to `http://localhost:7511/myindex/mycollection/AVkDBl3YsT6qHI7MxLz0` with an empty body (take a look at the [API Reference](/api-reference/?http#delete) if you don't want to try).
+Now, we'll let you figure out what happens when we send a `DELETE` request to `http://localhost:7512/myindex/mycollection/AVkDBl3YsT6qHI7MxLz0` with an empty body (take a look at the [API Reference](/api-reference/?http#delete) if you don't want to try).
 
 ### Document Search
 
 One thing that Elasticsearch is _really_ good at doing is... Searching! It enables to create extremely precise search queries, thanks to its powerful query DSL. We wrote a [comprehensive cookbook](#elasticsearch-cookbook) to help you understand how it works in detail, but let's take a look at a couple of simple examples, just to get started.
 
-Say we want to [**find**](/api-reference/?http#search) all the documents within `mycollection`, via the HTTP protocol. To do it, we send a `POST` request to `http://localhost:7511/myindex/mycollection/_search` (we leave the body empty since we have no filters to apply to our query). Depending on the documents you have created in your database, the response will look like:
+Say we want to [**find**](/api-reference/?http#search) all the documents within `mycollection`, via the HTTP protocol. To do it, we send a `POST` request to `http://localhost:7512/myindex/mycollection/_search` (we leave the body empty since we have no filters to apply to our query). Depending on the documents you have created in your database, the response will look like:
 
 ```json
 {

--- a/guide/source/includes/essentials/_plugins.md
+++ b/guide/source/includes/essentials/_plugins.md
@@ -63,7 +63,7 @@ $ bin/kuzzle plugins --install --url https://github.com/kuzzleio/kuzzle-plugin-h
 $ pm2 restart KuzzleServer
 ```
 
-Once Kuzzle has restarted (that's what the second command is for) you can check the server information at `http://localhost:7511/?pretty=true` for the new `hello` endpoint:
+Once Kuzzle has restarted (that's what the second command is for) you can check the server information at `http://localhost:7512/?pretty=true` for the new `hello` endpoint:
 
 ```json
 {
@@ -88,7 +88,7 @@ Once Kuzzle has restarted (that's what the second command is for) you can check 
 
 ```
 
-Which means you can call the `http://localhost:7511/kuzzle-plugin-helloworld/hello/` route and get the following response:
+Which means you can call the `http://localhost:7512/kuzzle-plugin-helloworld/hello/` route and get the following response:
 
 ```json
 {

--- a/guide/source/includes/essentials/_security.md
+++ b/guide/source/includes/essentials/_security.md
@@ -72,7 +72,7 @@ The `action permission` value can be set either to:
 You can find a **comprehensive summary of all the available controllers** and actions by sending a `GET` request to the root endpoint of the Kuzzle API via the HTTP protocol:
 
 ```bash
-$ curl -XGET http://localhost:7511/\?pretty\=true
+$ curl -XGET http://localhost:7512/\?pretty\=true
 ```
 
 Take a look at the example below:

--- a/guide/source/includes/quickstart/_index.md
+++ b/guide/source/includes/quickstart/_index.md
@@ -31,16 +31,16 @@ Your terminal will show the log messages of Kuzzle's components starting. After 
 kuzzle_1         | [✔] Kuzzle server ready
 ```
 
-Your Kuzzle server is now ready to be used. For instance, you can hit the main HTTP API endpoint by browsing the page <a href="http://localhost:7511?pretty=true">http://localhost:7511?pretty=true</a> or via cURL on the command line:
+Your Kuzzle server is now ready to be used. For instance, you can hit the main HTTP API endpoint by browsing the page <a href="http://localhost:7512?pretty=true">http://localhost:7512?pretty=true</a> or via cURL on the command line:
 
 ```bash
-$ curl "http://localhost:7511/?pretty=true"
+$ curl "http://localhost:7512/?pretty=true"
 ```
 
 Kuzzle will respond you with a list of the existing routes.
 
 <aside class="success">
-Kuzzle is up and running. It will accept requests at <code>localhost:7511</code>:
+Kuzzle is up and running. It will accept requests at <code>localhost:7512</code>:
 <ul>
   <li>via <strong>standard HTTP requests,</strong></li>
   <li>via a <strong>Websocket</strong> client (like the <a href="https://github.com/kuzzleio/sdk-javascript">Javascript SDK</a>),</li>

--- a/guide/source/includes/quickstart/_index.md
+++ b/guide/source/includes/quickstart/_index.md
@@ -40,11 +40,11 @@ $ curl "http://localhost:7511/?pretty=true"
 Kuzzle will respond you with a list of the existing routes.
 
 <aside class="success">
-Kuzzle is up and running. It will accept requests at the following addresses:
+Kuzzle is up and running. It will accept requests at <code>localhost:7511</code>:
 <ul>
-  <li><code>localhost:7511</code> via <strong>standard HTTP requests,</strong></li>
-  <li><code>localhost:7513</code> via a <strong>Websocket</strong> client (like the <a href="https://github.com/kuzzleio/sdk-javascript">Javascript SDK</a>),</li>
-  <li><code>localhost:7512</code> via <strong>Socket.IO</strong> (used as a fallback by the SDK on browsers that do not provide Websocket support).</li>
+  <li>via <strong>standard HTTP requests,</strong></li>
+  <li>via a <strong>Websocket</strong> client (like the <a href="https://github.com/kuzzleio/sdk-javascript">Javascript SDK</a>),</li>
+  <li>via <strong>Socket.IO</strong> (used as a fallback by the SDK on browsers that do not provide Websocket support).</li>
 </ul>
 </aside>
 

--- a/sdk-reference/source/includes/_kuzzle.md
+++ b/sdk-reference/source/includes/_kuzzle.md
@@ -8,20 +8,11 @@ Connects to a Kuzzle instance.
 
 
 ```js
-/*
- As this SDK embarks two protocols instead of just one (WebSocket and SocketIO),
- the "port" option has been replaced by a "wsPort" and "ioPort" ones, used
- to set, respectively, the WebSocket port and the SocketIO one.
-
- These ports are defaulted to Kuzzle default values, so you only have to change
- them if you modify the protocols default values server-side.
- */
 var kuzzle = new Kuzzle('localhost', {
   defaultIndex: 'some index',
   autoReconnect: true,
   headers: {someheader: "value"},
-  ioPort: 7512,
-  wsPort: 7513
+  port: 7512
 });
 
 // A callback is also available and will be invoked once connected to the Kuzzle instance:
@@ -81,21 +72,18 @@ Available options:
 | ``connect`` | string | Manually or automatically connect to the Kuzzle instance | ``auto`` |
 | ``defaultIndex`` | string | Set the default index to use | |
 | ``headers`` | JSON object | Common headers for all sent documents | |
-| ``ioPort`` | integer | (Javascript SDK only) Kuzzle network port for socket.io | 7512 |
 | ``metadata`` | JSON object | Common metadata, will be sent to all future requests | |
 | ``offlineMode`` | string | Offline mode configuration | ``manual`` |
-| ``port`` | integer | (All SDKs except Javascript) Kuzzle network port | 7512 |
+| ``port`` | integer | Kuzzle network port | 7512 |
 | ``queueTTL`` | integer | Time a queued request is kept during offline mode, in milliseconds | ``120000`` |
 | ``queueMaxSize`` | integer | Number of maximum requests kept during offline mode | ``500`` |
 | ``replayInterval`` | integer | Delay between each replayed requests, in milliseconds | ``10`` |
 | ``reconnectionDelay`` | integer | number of milliseconds between reconnection attempts | ``1000`` |
 | ``sslConnection`` | boolean | Switch Kuzzle connection to SSL mode | ``false`` |
-| ``wsPort`` | integer | (Javascript SDK only) Kuzzle network port for websocket | 7513 |
 
 **Notes:**
 
 * the ``offlineMode`` option only accepts the ``manual`` and ``auto`` values
-* the Javascript SDK accepts `ioPort` and `wsPort` options instead of the `port` one. This is because this SDK supports 2 network protocols to ensure maximum performances AND compatibility depending on browsers capabilities
 
 ### Callback response
 
@@ -113,18 +101,16 @@ If the `connect` option is set to `manual`, the callback will be called after th
 | ``defaultIndex`` | string | Kuzzle's default index to use | get |
 | ``headers`` | JSON object | Common headers for all sent documents. | get/set |
 | ``host`` | string | Target Kuzzle host name/address | get/set |
-| ``ioPort`` | integer | (Javascript SDK only) Kuzzle network port for socket.io | 7512 |
 | ``jwtToken`` | string | Token used in requests for authentication. | get/set |
 | ``metadata`` | JSON object | Common metadata, will be sent to all future requests | get/set |
 | ``offlineQueue`` | JSON object | Contains the queued requests during offline mode | get/set |
 | ``offlineQueueLoader`` | function | Called before dequeuing requests after exiting offline mode, to add items at the beginning of the offline queue | get/set |
-| ``port`` | integer | (All SDKs except Javascript) Kuzzle network port | 7512 |
+| ``port`` | integer | Kuzzle network port | 7512 |
 | ``queueFilter`` | function | Called during offline mode. Takes a request object as arguments and returns a boolean, indicating if a request can be queued | get/set |
 | ``queueMaxSize`` | integer | Number of maximum requests kept during offline mode | get/set |
 | ``queueTTL`` | integer | Time a queued request is kept during offline mode, in milliseconds | get/set |
 | ``replayInterval`` | integer | Delay between each replayed requests | get/set |
 | ``reconnectionDelay`` | integer | number of milliseconds between reconnection attempts | get |
-| ``wsPort`` | integer | (Javascript SDK only) Kuzzle network port for websocket | 7513 |
 
 **Notes:**
 
@@ -137,7 +123,6 @@ If the `connect` option is set to `manual`, the callback will be called after th
 * if ``queueMaxSize`` is set to ``0``, an unlimited number of requests is kept until the buffer is flushed
 * the ``offlineQueueLoader`` must be set with a function, taking no argument, and returning an array of objects containing a `query` member with a Kuzzle query to be replayed, and an optional `cb` member with the corresponding callback to invoke with the query result
 * the ``host`` and ``port`` properties can be changed, but it will only be in effect at the next ``connect`` call
-* the Javascript SDK accepts `ioPort` and `wsPort` options instead of the `port` one. This is because this SDK supports 2 network protocols to ensure maximum performances AND compatibility depending on browsers capabilities
 
 ## Offline mode
 
@@ -1413,8 +1398,8 @@ catch (ErrorException $e) {
 
 Log a user according to a strategy and credentials.
 
-If the Kuzzle response contains a JWT Token, the SDK token is set and the `loginAttempt` event is fired immediately with the following object:  
-`{ success: true }`  
+If the Kuzzle response contains a JWT Token, the SDK token is set and the `loginAttempt` event is fired immediately with the following object:
+`{ success: true }`
 This is the case, for instance, with the `local` authentication strategy.
 
 If the request succeeds but there is no token, then it means that the chosen strategy is a two-steps authentication method, like OAUTH. In that case, the `loginAttempt` event is **not** fired. To complete the login attempt, the `setJwtToken` method must be called either with a token or with an appropriate Kuzzle response.


### PR DESCRIPTION
following kuzzleio/kuzzle-proxy#48

Kuzzle Proxy will now expose a unique port (7512) for both 3 core protocols.
