### PR TITLE
Remove obsolete documentation file

### DIFF
--- a/guide/source/includes/essentials/_installation-windows.md
+++ b/guide/source/includes/essentials/_installation-windows.md
@@ -1,9 +1,0 @@
-## Installing Kuzzle on Windows and Mac OS (via Docker)
-
-Even though we don't provide support for these OSes you can install Kuzzle on those for development purposes.  
-The most efficient way to install Kuzzle on Windows or Mac OS is via **Docker**. This is done pretty much the same way as described in the [previous section](#installing-kuzzle-via-docker).
-
-* Follow these instructions to install [Docker for Windows](https://docs.docker.com/docker-for-windows/).
-* Follow these instructions to install [Docker for Mac OS](https://docs.docker.com/docker-for-mac/).
-
-Now that Docker is working, you can install Kuzzle just as described in the [previous section](#installing-kuzzle-via-docker).


### PR DESCRIPTION
Delete the now obsolete and unused "Install on Windows/MacOS" documentation file

(no impact on the documentation, the file was just there, unused)