### PR TITLE
Plugins documentation improvement and add missing plugins options

### DIFF
--- a/guide/source/includes/essentials/_plugins.md
+++ b/guide/source/includes/essentials/_plugins.md
@@ -5,7 +5,7 @@ That's quite legitimate: some logic is sensible and cannot live on the client.
 
 For example, imagine your application needs to leverage a **third-party payment system**, such as Braintree. You don't want to put the client in charge of bearing API keys and tokens. Also, you will probably want to **keep track of orders** and payments, once the transactions successfully end. This should be also a concern of your backend. Also, you are not likely to allow your customers to purchase more items than available, right? At some point, **your backend has to validate the transaction** by comparing the ordered quantity with the available stocks.
 
-To solve this problem, Kuzzle ships with a powerful **[Plugin System](/plugin-reference)** that enables you to add features to your server in a modular fashion. With Kuzzle Plugins you can
+To make sure Kuzzle fits whatever needs you might have, it includes a powerful **[Plugin System](/plugin-reference)** allowing you to add features to your server in a modular fashion. With Kuzzle Plugins you can:
 
 * use an existing plugin from the Kuzzle Plugins ecosystem (such as the [OAuth2 Authentication strategy](https://github.com/kuzzleio/kuzzle-plugin-auth-passport-oauth) or the [MQTT Protocol](https://github.com/kuzzleio/kuzzle-plugin-mqtt));
 * [create your own plugin](/plugin-reference/#writing-plugin-code) from scratch.
@@ -16,41 +16,43 @@ There are three main Plugin types, each one has specific features.
 
 #### Core Plugins
 
-They are the most common type of plugins and are meant to extend the Kuzzle Core features. They are plugged on the Kuzzle Core at startup and execute on its same thread. A Core Plugin can extend Kuzzle with the following features:
+They are the most common type of plugins and are meant to extend the Kuzzle Core features. They are plugged on the Kuzzle Core at startup and they share its execution thread. A Core Plugin can extend Kuzzle with the following features:
 
-[Listen asynchronously](/plugin-reference#listener-plugins), and perform operations that depend on data-related events. The chunk of data involved with the event is passed to the triggered callback, but the Kuzzle Core continues its execution without waiting for the callback to return, nor receiving the return value of the callback.
+[Listen asynchronously](/plugin-reference#listener-plugins), and perform operations that depend on data-related events. The chunk of data involved with the event is passed to the triggered callback, but the Kuzzle Core continues its execution without waiting for the callback to return.
 
   _Example - "Write a log to a third-party log system every time a document is deleted"_. The [Logger Plugin](https://github.com/kuzzleio/kuzzle-plugin-logger), shipped with Kuzzle, uses this feature to log all the data-related events.
 
-[Listen synchronously](/plugin-reference#pipe-plugins), and perform operations that depend on data-related events. many synchronous listeners can be chained, forming a pipeline. The chunk of data involved with the event is passed to the plugin pipeline and can be modified. The Kuzzle Core waits for the pipeline to return and receives the returned value (which must be the processed chunk of data). The pipeline can even stop a request life-cycle, returning a standard Error to the Kuzzle Core.
+[Listen synchronously](/plugin-reference#pipe-plugins), and perform operations that depend on data-related events. Multiple synchronous listeners can be chained, forming a pipeline. The chunk of data involved with the event is passed to one plugin to another in the pipeline, and it can be modified. The Kuzzle Core waits for the pipeline to return and receives then processes the potentially modified value. A plugin can even stop a request life-cycle, by returning a standard Error to the Kuzzle Core.
 
-  _Example - "Compare the ordered quantity with the available stocks and return an error if ordered is greater than stocks"_.
+  _Example - "Compare the ordered quantity with the available stocks and return an error if the amount of ordered items exceeds the stocks"_.
 
 [Add a controller route](/plugin-reference#controllers) to expose new actions to the API.
 
   _Example - "Expose a `checkout` API endpoint that handles the Braintree payment process"_.
 
-[Add an authentication strategy](/plugin-reference#authentication-plugin) the User authentication system.
+[Add an authentication strategy](/plugin-reference#authentication-plugin) to the User authentication system.
 
   _Example - "Enable Kuzzle to authenticate users via the OAuth strategy"_
-  Kuzzle ships with an Authentication Plugin already bundled in its Community Edition, the [Local Strategy Plugin](https://github.com/kuzzleio/kuzzle-plugin-auth-passport-local).
+  Kuzzle ships with an Authentication Plugin already bundled in its Community Edition, the [Local Strategy Plugin](https://github.com/kuzzleio/kuzzle-plugin-auth-passport-local). Thanks to PassportJS, more than 300 authentication strategies are readily available.
 
 #### Worker Plugins
-[Workers Plugins](/plugin-reference#worker-plugins) are Core Plugins that run on a separate process. The only feature they can add is to [asynchronously listen to data-related events](/plugin-reference#listener-plugins). They are useful when performing costly operations as they have no impact on Kuzzle performances.
+
+[Workers Plugins](/plugin-reference#worker-plugins) are Core Plugins running on separate processes. The only feature they can add is to [asynchronously listen to data-related events](/plugin-reference#listener-plugins). They are useful when performing costly operations as they have no impact on Kuzzle performances.
 
 _Example - "Compute a complex data-mining operation and commit the result to a third-party Business-Intelligence platform every time a document is changed"._
 
 #### Protocol Plugins
+
 [Protocol Plugins](/plugin-reference#protocol-plugins) extend Kuzzle networking capabilities by adding new network protocols.
 
 _Example - "Enable Kuzzle to interact with XMPP-oriented services"_
-Kuzzle ships with a Protocol Plugin already bundled in its Community Edition, the [Websocket Plugin](https://github.com/kuzzleio/kuzzle-plugin-websocket).
+Kuzzle ships with a Protocol Plugin already bundled in its Community Edition, the [MQTT Plugin](https://github.com/kuzzleio/kuzzle-plugin-mqtt).
 
 ### Examples
 
-This example is a very dummy one. We are going to install the **Hello World Controller Plugin**, which opens a new API endpoint that simply... Greets the client! Not very useful, except for the sake of this example.
+This example is a simplistic one: we are going to install the **Hello World Plugin**, adding a new API endpoint that simply... greets the client! Not very useful, except for the sake of this example.
 
-To install a Plugin, you just need to make it accessible within the `plugins/enabled` directory (relative to the path of the Kuzzle installation directory). A common practice is to copy the Plugin code in `plugins/available` and create a symbolic link in `plugins/enabled` pointing to it. This way, enabling and disabling a plugin is just a matter of creating or deleting a symbolic link.
+To install a Plugin, you just need to make it accessible within the `plugins/enabled` directory (relative to the path of the Kuzzle installation directory). A common practice is to copy the Plugin code in the `plugins/available` directory, and to create a symbolic link in `plugins/enabled` pointing to it. This way, enabling and disabling a plugin is just a matter of creating or deleting a symbolic link.
 
 <aside class="notice">
 If you are running Kuzzle in a Docker container, you will need to enter the container to access the installation directory.
@@ -91,7 +93,7 @@ Once Kuzzle has restarted (that's what the last command is for) you can check th
 
 ```
 
-Which means you can call the `http://localhost:7512/kuzzle-plugin-helloworld/hello/` route and get the following response:
+Which means you can call the `http://localhost:7512/_plugin/kuzzle-plugin-helloworld/hello/` route and get the following response:
 
 ```json
 {
@@ -111,27 +113,4 @@ To get a deeper insight on how Plugins work in Kuzzle, please refer to the [Plug
 
 ### Managing Plugins
 
-As seen in the previous example, managing Plugins is really just a matter of moving files and symbolic links around.
-
-#### Installing, removing, enabling and disabling Plugins
-
-When starting, Kuzzle (both Core and Proxy) looks for Plugins in the `plugins/enabled` directory. Valid Plugins are well-formed NPM modules (i.e. they have a `package.json` at their root) or simple NodeJS requireables (i.e. they have at their root a valid `index.js`).
-
-A common practice is to copy the Plugin code in `plugins/available` and create a symbolic link in `plugins/enabled` pointing to it. This way, enabling and disabling a plugin is just a matter of creating or deleting a symbolic link.
-
-#### Configuring Plugins
-
-When initializing a Plugin, Kuzzle (both Core and Proxy) calls its `init(customConfig, context)` method, passing the [context](/plugin-reference/#the-plugin-context) and the custom configuration. Custom configuration parameters are specified for each plugin in the `plugins` object of the [Kuzzle configuration file](#configuring-kuzzle).
-
-```json
-{
-  "plugins": {
-    "kuzzle-plugin-foobar": {
-      "option_1": "option_value",
-      "option_2": "option_value"
-    }
-  }
-}
-```
-
-Each Plugin is responsible of handling the custom configuration parameters and Kuzzle has no opinion on how to do it. Whether the custom configuration is merged with the defaults or not entirely depends on the implementation of the `init` function.
+To learn about how to manage or configure plugins, please check our [Plugin reference documentation].

--- a/plugin-reference/source/includes/_managing-plugins.md
+++ b/plugin-reference/source/includes/_managing-plugins.md
@@ -1,0 +1,30 @@
+### Managing Plugins
+
+#### Installing, removing, enabling and disabling plugins
+
+When starting, Kuzzle (both Core and Proxy) looks for directories in the `plugins/enabled` directory. Valid Plugins directories either contain a well-formed NPM module (i.e. they have a `package.json` file in their root directory), or are a simple NodeJS requireables (i.e. they have a valid `index.js` file in their root directory).
+
+In either cases, a plugin must meet a certain number of [prerequisites](/plugin-reference/#plugin-creation-prerequisites) to allow Kuzzle to use it.
+
+TO install a plugin, the recommended practice is to copy the directory containing it in the `plugins/available` folder and to create a symbolic link in the `plugins/enabled` one, pointing to it. This way, enabling and disabling a plugin is just a matter of creating or deleting a symbolic link.
+
+Each plugin is a separate and independant entity, and Kuzzle will try to load it as is. If it has dependencies, you must ensure these are installed. For instance, by running the command `npm install` from inside a plugin directory, if the plugin is a NPM module.
+
+#### Configuring Plugins
+
+When initializing a Plugin, Kuzzle (both Core and Proxy) calls its `init(customConfig, context)` method, passing the [context](/plugin-reference/#the-plugin-context) and the custom configuration.
+
+Custom configuration parameters are specified for each plugin in the `plugins` object of the [Kuzzle configuration file](#configuring-kuzzle).
+
+```json
+{
+  "plugins": {
+    "kuzzle-plugin-foobar": {
+      "option_1": "option_value",
+      "option_2": "option_value"
+    }
+  }
+}
+```
+
+Each Plugin is responsible of handling its own custom configuration parameters and Kuzzle has no opinion on how to do it. Whether the custom configuration is merged with the defaults or not entirely depends on the implementation of the plugin's `init` function.

--- a/plugin-reference/source/includes/_plugin-prerequisites.md
+++ b/plugin-reference/source/includes/_plugin-prerequisites.md
@@ -15,7 +15,9 @@ To determine the Plugin name, Kuzzle looks for the `name` field in the `package.
 
 ### Custom Plugin configuration
 
-When initializing a Plugin, Kuzzle calls its `init(customConfig, context)` method, passing the [context](/plugin-reference/#the-plugin-context) and the custom configuration. Custom configuration parameters are specified for each plugin in the `plugins` object of the [Kuzzle configuration file](#configuring-kuzzle).
+When initializing a Plugin, Kuzzle calls its `init(customConfig, context)` method, passing the [context](/plugin-reference/#the-plugin-context) and the plugin's custom configuration.
+
+Custom configuration parameters are specified for each plugin in the `plugins` object of the [Kuzzle configuration file](#configuring-kuzzle).
 
 ```json
 {
@@ -30,14 +32,15 @@ When initializing a Plugin, Kuzzle calls its `init(customConfig, context)` metho
 
 Each Plugin is responsible of handling the custom configuration parameters and Kuzzle has no opinion on how to do it. Whether the custom configuration is merged with the defaults or not entirely depends on the implementation of the `init` function.
 
-Within custom configuration, there are a few reserved words used by Kuzzle to configure how a plugin is loaded:
+Within a plugin's custom configuration, there are a few reserved words used by Kuzzle to configure how a plugin is loaded:
 
 ```json
 {
   "plugins": {
     "kuzzle-plugin-foobar": {
-      "threads": 0,
-      "privileged": false
+      "killTimeout": 6000,
+      "maxMemoryRestart": "200M",
+      "threads": 0
     }
   }
 }
@@ -47,8 +50,9 @@ Where:
 
 | Keyword | Type | Default Value |Description                  |
 |---------|------|---------------|-----------------------------|
+| `killTimeout` | `unsigned integer` | `6000 ` | (if `threads` > 0) Time (in milliseconds) to wait for a plugin to shut down before killing it |
+| `maxMemoryRestart` | `string` | `1G` | (if `threads` > 0) Maximum memory usage of a worker plugin. If exceeded, the plugin is restarted. <br>Examples: `10K` (10KB), `200M` (200MB), `3G` (3GB)|
 |`threads`|`unsigned integer`|`0`| If > 0, the plugin will be treated as a worker plugin (see below) |
-|`privileged`|`boolean`|`false`| If `true`, the plugin is loaded with privileged access to the running Kuzzle instance (see Plugin Context below)<br/>Ignored if `threads` is greater than `0` |
 
 ### Plugin init function
 

--- a/plugin-reference/source/index.md
+++ b/plugin-reference/source/index.md
@@ -9,6 +9,7 @@ toc_footers:
   - <a href="http://github.com/tripit/slate">Documentation Powered by Slate</a>
 
 includes:
+  - managing-plugins
   - plugin-prerequisites
   - creating-plugins
   - plugin-context


### PR DESCRIPTION
# Description

This PR solves 2 problems:

* plugins management documentation is located in the `guide` documentation, where one would probably look for it first in the `plugins reference` part (I know I did).  
The `managing plugins` section in the `guide` documentation has been moved into the `Plugins reference` documentation, and the `guide` now shows only a link to it
* The `maxMemoryRestart` and `killTimeout` worker plugins options weren't documented

# Other changes

A few wording improvements here and there.
