### PR TITLE
Fix erroneous auth:login options description

### DIFF
--- a/api-reference/source/includes/_authController.md
+++ b/api-reference/source/includes/_authController.md
@@ -179,7 +179,12 @@ Gets the rights of the user identified by the `JSON Web Token` provided in the q
   "strategy": "<passportjs_strategy>",
 
   // JWT expiration delay (optional - kuzzle will use server default value if not set)
-  // expressed in seconds or a string describing a time span. Eg: 60, "2 days", "10h", "7d", "1y"
+  //   - if this option is a raw number (not enclosed between quotes), then
+  //     it represents the expiration delay in milliseconds
+  //   - if this option is a string, then its content is parsed by the "ms" library
+  //     For instance: "6d" (6 days), "10h" (10 hours), ...
+  //     (see https://www.npmjs.com/package/ms for the complete list of accepted
+  //      formats)
   "expiresIn": "<expiresIn>",
 
   // set of parameters depending of the chosen strategy. Example for "local" strategy:
@@ -203,7 +208,7 @@ Gets the rights of the user identified by the `JSON Web Token` provided in the q
     // authentication strategy identifier (optional - kuzzle will use "local" strategy if not set)
     "strategy": "<passportjs_strategy>",
 
-    // jwt token expiration time (optional - kuzzle will use server default value if not set)
+    // JWT expiration delay (optional - kuzzle will use server default value if not set)
     //   - if this option is a raw number (not enclosed between quotes), then
     //     it represents the expiration delay in milliseconds
     //   - if this option is a string, then its content is parsed by the "ms" library

--- a/api-reference/source/includes/_authController.md
+++ b/api-reference/source/includes/_authController.md
@@ -175,7 +175,7 @@ Gets the rights of the user identified by the `JSON Web Token` provided in the q
 
 ```litcoffee
 {
-  // authentication strategy identifier (optionnal : kuzzle will use "local" strategy if not set)
+  // authentication strategy identifier (optional : kuzzle will use the "local" strategy if not set)
   "strategy": "<passportjs_strategy>",
 
   // JWT expiration delay (optional - kuzzle will use server default value if not set)
@@ -205,7 +205,7 @@ Gets the rights of the user identified by the `JSON Web Token` provided in the q
   "action": "login",
 
   "body": {
-    // authentication strategy identifier (optional - kuzzle will use "local" strategy if not set)
+    // authentication strategy identifier (optional - kuzzle will use the "local" strategy if not set)
     "strategy": "<passportjs_strategy>",
 
     // JWT expiration delay (optional - kuzzle will use server default value if not set)

--- a/api-reference/source/includes/_authController.md
+++ b/api-reference/source/includes/_authController.md
@@ -178,7 +178,7 @@ Gets the rights of the user identified by the `JSON Web Token` provided in the q
   // authentication strategy identifier (optionnal : kuzzle will use "local" strategy if not set)
   "strategy": "<passportjs_strategy>",
 
-  // jwt token expiration time (optional - kuzzle will use server default value if not set)
+  // JWT expiration delay (optional - kuzzle will use server default value if not set)
   // expressed in seconds or a string describing a time span. Eg: 60, "2 days", "10h", "7d", "1y"
   "expiresIn": "<expiresIn>",
 
@@ -204,7 +204,12 @@ Gets the rights of the user identified by the `JSON Web Token` provided in the q
     "strategy": "<passportjs_strategy>",
 
     // jwt token expiration time (optional - kuzzle will use server default value if not set)
-    // expressed in seconds or a string describing a time span. Eg: 60, "2 days", "10h", "7d", "1y"
+    //   - if this option is a raw number (not enclosed between quotes), then
+    //     it represents the expiration delay in milliseconds
+    //   - if this option is a string, then its content is parsed by the "ms" library
+    //     For instance: "6d" (6 days), "10h" (10 hours), ...
+    //     (see https://www.npmjs.com/package/ms for the complete list of accepted
+    //      formats)
     "expiresIn": "<expiresIn>",
 
     // set of parameters depending of the chosen strategy. Example for "local" strategy:


### PR DESCRIPTION
# Description

The `expiresIn` option description for the `auth:login` API route was erroneous: 

* if the provided expiration delay is a number, then it's expressed in **milliseconds** (and not in seconds)
* for a complete documentation on the accepted string formats, we should mention that the provided option is parsed by the [ms](https://www.npmjs.com/package/ms) module

# Solved issue

#94 
