### PR TITLE
Fix outdated PM2 configuration

### DIFF
--- a/guide/source/includes/essentials/_installation-linux.md
+++ b/guide/source/includes/essentials/_installation-linux.md
@@ -112,8 +112,7 @@ $ echo "apps:
      script: ${KUZZLE_CORE_INSTALL_DIR}/bin/kuzzle
      args: start
      env:
-       kuzzle_server__http__port: 7510
-       kuzzle_services__proxyBroker__host: localhost
+       NODE_ENV: production
   " > ~/kuzzle/pm2.conf.yml
 ```
 


### PR DESCRIPTION
# Description

In the pm2 configuration example in the `guide` documentation, the Kuzzle options are removed (the `.kuzzlerc` configuration file should be favored anyway).

Previously documented options have been replaced by `NODE_ENV=production` to maximize Kuzzle performances

# Solved issue

#85 
