### PR TITLE
Remove the profileIds field from the request examples of the security/createFirstAdmin route

### DIFF
--- a/api-reference/source/includes/_securityController.md
+++ b/api-reference/source/includes/_securityController.md
@@ -40,7 +40,6 @@
   "_id": "<userId>",                      // Optional. If not provided, will be generated automatically.
 
   "body": {
-    "profileIds": ["<profileId>"],       // Mandatory. The profile ids for the user
     "name": "John Doe",                   // Additional optional User properties
     ...
   }
@@ -55,7 +54,6 @@
   "_id": "<userId>",                      // Optional. If not provided, will be generated automatically.
 
   "body": {
-    "profileIds": ["<profileId>"],        // Mandatory. The profile ids for the user
     "name": "John Doe",                   // Additional optional User properties
     ...
     "password": "MyPassword"              // ie: Mandatory for "local" authentication plugin


### PR DESCRIPTION
The field profileIds must not be provided to the createFirstAdmin route as it is set directly by the route.