### PR TITLE
Add a new Mapping section under Essentials/persisted

### DIFF
--- a/api-reference/source/includes/_indexController.md
+++ b/api-reference/source/includes/_indexController.md
@@ -5,7 +5,7 @@
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7512/<index>`
+>**URL:** `http://kuzzle:7512/<index>/_create`
 >**Method:** `POST`
 
 <section class="others"></section>

--- a/guide/source/includes/essentials/_persisted.md
+++ b/guide/source/includes/essentials/_persisted.md
@@ -276,11 +276,12 @@ Which gives, as a result, the following response:
 
 ### Document mapping
 
-As previously said, Kuzzle relies on Elasticsearch to persist documents. Elasticsearch uses a mapping internaly to match
+As previously said, Kuzzle relies on Elasticsearch to persist documents. Elasticsearch uses a mapping internally to match
 a document field to a field type. This mapping is attached to a `collection` (a `type` in Elasticsearch terminology).
-If this mapping has not been defined, Elasticsearch will try to create this mapping automatically with the input documents.
+If no mapping is defined, Elasticsearch will infer it automatically from input documents.
 
-If you want to define this mapping yourself, Kuzzle provides a route to set it.
+ou may want to define mappings manually, especially to provide more details to Elasticsearch on how it should interpret the documents stored in your collections.
+To do so, Kuzzle expose a mapping creation API route.
 This is done by sending a `PUT` request to the API endpoint `http://localhost:7512/myindex/mycollection/_mapping` with the body set to your mapping:
 
 ```json
@@ -314,7 +315,7 @@ Which gives us the response...
 Here we defined a new field called `someField` of type `date` in our collection `mycollection`. This is especially useful when
 dealing with capabilities such as specific types (`date`, `geo_shape`, ...), full-text search and complex data structures (`nested`, ...) of Elasticsearch.
 As the mapping of the collection can not be changed once it is set (even if Elasticsearch did it automatically for you),
-we advise you to define it yourself to avoid surprises.
+you should almost always define mappings when creating collections, preferably before sending documents in them.
 
 The syntax to use is the one defined by [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/mapping.html). 
 

--- a/guide/source/includes/essentials/_persisted.md
+++ b/guide/source/includes/essentials/_persisted.md
@@ -12,7 +12,8 @@ In Kuzzle, data is organized in the following way:
 
 Kuzzle ships with a full data [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) API that enables you to operate in many ways on your documents.
 
-Let's [**create a new document**](/api-reference/#create48), for example, in `mycollection`, within `myindex` via the HTTP protocol. This is done by sending a `POST` request to the API endpoint `http://localhost:7512/myindex/mycollection/_create` with the body set to
+Let's [**create a new document**](/api-reference/#create48), for example, in `mycollection`, within `myindex` via the HTTP protocol.
+This is done by sending a `POST` request to the API endpoint `http://localhost:7512/myindex/mycollection/_create` with the body set to
 
 ```json
 {
@@ -271,6 +272,52 @@ Which gives, as a result, the following response:
   }
 }
 ```
+
+
+### Document mapping
+
+As previously said, Kuzzle relies on Elasticsearch to persist documents. Elasticsearch uses a mapping internaly to match
+a document field to a field type. This mapping is attached to a `collection` (a `type` in Elasticsearch terminology).
+If this mapping has not been defined, Elasticsearch will try to create this mapping automatically with the input documents.
+
+If you want to define this mapping yourself, Kuzzle provides a route to set it.
+This is done by sending a `PUT` request to the API endpoint `http://localhost:7512/myindex/mycollection/_mapping` with the body set to your mapping:
+
+```json
+{
+  "properties": {
+    "someField": {
+      "type": "date"
+    }
+  }
+}
+```
+
+Which gives us the response...
+
+```json
+{
+  "action": "updateMapping", 
+  "collection": "mycollection", 
+  "controller": "collection", 
+  "error": null, 
+  "index": "myindex", 
+  "metadata": null, 
+  "requestId": "8acca50e-592d-4f0d-962c-31719b11e171", 
+  "result": {
+    "acknowledged": true
+  }, 
+  "status": 200
+}
+```
+
+Here we defined a new field called `someField` of type `date` in our collection `mycollection`. This is especially useful when
+dealing with capabilities such as specific types (`date`, `geo_shape`, ...), full-text search and complex data structures (`nested`, ...) of Elasticsearch.
+As the mapping of the collection can not be changed once it is set (even if Elasticsearch did it automatically for you),
+we advise you to define it yourself to avoid surprises.
+
+The syntax to use is the one defined by [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/mapping.html). 
+
 
 #### Where do we go from here?
 


### PR DESCRIPTION
fixes #58
Boyscout: fix the `index:create` HTTP route documentation