### PR TITLE
Document the SearchResult object

### DIFF
--- a/sdk-reference/source/includes/_collection.md
+++ b/sdk-reference/source/includes/_collection.md
@@ -1054,10 +1054,11 @@ Returns the newly created `Room` object.
 ## scroll
 
 ```js
+// Using callbacks (NodeJS or Web Browser)
 kuzzle
   .collection('collection', 'index')
-  .scroll(scrollId, {scroll: "1m"}, function (err, res) {
-    res.documents.forEach(document => {
+  .scroll(scrollId, "1m", options, function (err, searchResult) {
+    searchResult.getDocuments().forEach(function (document) {
       console.log(document.toString());
     });
   });
@@ -1065,9 +1066,9 @@ kuzzle
 // Using promises (NodeJS only)
 kuzzle
   .collection('collection', 'index')
-  .scrollPromise(scrollId, {scroll: "1m"})
-  .then(res => {
-    res.documents.forEach(document => {
+  .scrollPromise(scrollId, "1m", options)
+  .then(searchResult => {
+    searchResult.getDocuments().forEach(document => {
       console.log(document.toString());
     });
   });
@@ -1075,20 +1076,19 @@ kuzzle
 
 ```java
 Options opts = new Options();
-opts.setScroll("1m");
 
 kuzzle
   .collection("collection", "index")
-  .scroll(scrollId, opts, new ResponseListener<DocumentList>() {
+  .scroll(scrollId, "1m", opts, new ResponseListener<SearchResult>() {
     @Override
-    public void onSuccess(DocumentList result) {
-      for (Document doc : result.getDocuments()) {
+    public void onSuccess(SearchResult searchResult) {
+      for (Document doc : searchResult.getDocuments()) {
         // Get documents
       }
 
-      result.getTotal(); // return total of documents returned
+      searchResult.getTotal(); // return total of documents returned
 
-      result.getAggregations(): // return a JSONObject representing the aggregations response
+      searchResult.getAggregations(): // return a JSONObject representing the aggregations response
     }
 
     @Override
@@ -1109,7 +1109,7 @@ $kuzzle = new Kuzzle('localhost');
 $dataCollection = $kuzzle->collection('collection', 'index');
 
 try {
-  $searchResult = $dataCollection->scroll($scrollId, ['scroll' => '1m']);
+  $searchResult = $dataCollection->scroll($scrollId, '1m');
 
   // $searchResult instanceof SearchResult
   $searchResult->getTotal();
@@ -1128,14 +1128,7 @@ catch (ErrorException $e) {
 
 > Callback response:
 
-```json
-{ "total": 3,
-  "documents": [<Document>, <Document>, <Document>],
-  "aggregations": {
-    "aggs_name": {"aggregation": "object"}
-  }
-}
-```
+Resolves to an instantiated [SearchResult](#searchresult) object.
 
 <aside class="notice">
   There is a small delay between documents creation and their existence in our search layer, usually a couple of seconds. That means that a document that was just been created won't be returned by this function
@@ -1145,11 +1138,12 @@ Returns the next page of the scroll session, and the `scrollId` to be used by th
 A scroll session is always initiated by a `search` action by using the `scroll` argument; more information below.
 
 
-### search(filters, [options], callback)
+### scroll(scrollId, [options], callback)
 
 | Arguments | Type | Description |
 |---------------|---------|----------------------------------------|
-| ``scrollId`` | JSON object | The "scrollId" provided with the last scroll response or from the initial search request if it is the first scroll call |
+| ``scrollId`` | string | The "scrollId" provided with the last scroll response or from the initial search request if it is the first scroll call |
+| ``scroll`` | string | Re-initializes the scroll session timeout to its value |
 | ``options`` | JSON object | Optional parameters |
 | ``callback`` | function | Callback handling the response |
 
@@ -1159,7 +1153,6 @@ Available options:
 | Option | Type | Description | Default |
 |---------------|---------|----------------------------------------|---------|
 | ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
-| ``scroll`` | string | (mandatory) Re-initializes the scroll session timeout to its value | ``undefined`` |
 
 <aside class="notice">
   To get more information about scroll sessions, please refer to the <a href="/api-reference/#search">API reference documentation</a>.
@@ -1167,12 +1160,7 @@ Available options:
 
 ### Callback response
 
-Resolves to a `JSON object` containing:
-
-- the total number of matched documents
-- an `array` of `Document` objects
-- an `array` of `aggregations` objects if some are provided in the request (see the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/search-aggregations.html) for more details)
-
+Resolves to an instantiated [SearchResult](#searchresult) object.
 
 ## search
 
@@ -1209,10 +1197,11 @@ let filter = {
   }
 };
 
+// Using callbacks (NodeJS or Web Browser)
 kuzzle
   .collection('collection', 'index')
-  .search(filter, function (err, res) {
-    res.documents.forEach(document => {
+  .search(filter, function (err, searchResult) {
+    searchResult.getDocuments().forEach(function(document) {
       console.log(document.toString());
     });
   });
@@ -1221,8 +1210,8 @@ kuzzle
 kuzzle
   .collection('collection', 'index')
   .searchPromise({})
-  .then(res => {
-    res.documents.forEach(document => {
+  .then(searchResult => {
+    searchResult.getDocuments().forEach(document => {
       console.log(document.toString());
     });
   });
@@ -1272,16 +1261,16 @@ JSONObject filter = new JSONObject()
 
 kuzzle
   .collection("collection", "index")
-  .search(userFilter, new ResponseListener<DocumentList>() {
+  .search(filter, new ResponseListener<SearchResult>() {
     @Override
-    public void onSuccess(DocumentList result) {
-      for (Document doc : result.getDocuments()) {
+    public void onSuccess(SearchResult searchResult) {
+      for (Document doc : searchResult.getDocuments()) {
         // Get documents
       }
 
-      result.getTotal(); // return total of documents returned
+      searchResult.getTotal(); // return total of documents returned
 
-      result.getAggregations(): // return a JSONObject representing the aggregations response
+      searchResult.getAggregations(): // return a JSONObject representing the aggregations response
     }
 
     @Override
@@ -1354,18 +1343,11 @@ catch (ErrorException $e) {
 
 > Callback response:
 
-```json
-{ "total": 3,
-  "documents": [<Document>, <Document>, <Document>],
-  "aggregations": {
-    "aggs_name": {"aggregation": "object"}
-  }
-}
-```
+Resolves to an instantiated [SearchResult](#searchresult) object.
 
 
 <aside class="notice">
-There is a small delay between documents creation and their existence in our search layer, usually a couple of seconds. That means that a document that was just been created won't be returned by this function
+  There is a small delay between documents creation and their existence in our search layer, usually a couple of seconds. That means that a document that was just been created won't be returned by this function
 </aside>
 
 Executes a search on the data collection.
@@ -1384,7 +1366,9 @@ Available options:
 | Option | Type | Description | Default |
 |---------------|---------|----------------------------------------|---------|
 | ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
-| ``scroll`` | string | Indicates to start a scroll session by providing the session timeout | ``undefined`` |
+| ``scroll`` | string | Start a scroll session, with a time to live equals to this parameter's value following the [Elastisearch time format](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/common-options.html#time-units) | ``undefined`` |
+| ``from`` | number | Provide the starting offset of the request (used to paginate results) | ``0`` |
+| ``size`` | number | Provide the maximum number of results of the request (used to paginate results) | ``10`` |
 
 <aside class="notice">
   To get more information about scroll sessions, please refer to the <a href="/api-reference/#search">API reference documentation</a>.
@@ -1392,11 +1376,7 @@ Available options:
 
 ### Callback response
 
-Resolves to a `JSON object` containing:
-
-- the total number of matched documents
-- an `array` of `Document` objects
-- an `array` of `aggregations` objects if some are provided in the request (see the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/search-aggregations.html) for more details)
+Resolves to an instantiated [SearchResult](#searchresult) object.
 
 ## setHeaders
 

--- a/sdk-reference/source/includes/_collection.md
+++ b/sdk-reference/source/includes/_collection.md
@@ -1066,7 +1066,7 @@ kuzzle
 // Using promises (NodeJS only)
 kuzzle
   .collection('collection', 'index')
-  .scrollPromise(scrollId, {scroll: '1m'}, options)
+  .scrollPromise(scrollId, {scroll: '1m'})
   .then(searchResult => {
     searchResult.getDocuments().forEach(document => {
       console.log(document.toString());

--- a/sdk-reference/source/includes/_collection.md
+++ b/sdk-reference/source/includes/_collection.md
@@ -1057,7 +1057,7 @@ Returns the newly created `Room` object.
 // Using callbacks (NodeJS or Web Browser)
 kuzzle
   .collection('collection', 'index')
-  .scroll(scrollId, "1m", options, function (err, searchResult) {
+  .scroll(scrollId, {scroll: '1m'}, function (err, searchResult) {
     searchResult.getDocuments().forEach(function (document) {
       console.log(document.toString());
     });
@@ -1066,7 +1066,7 @@ kuzzle
 // Using promises (NodeJS only)
 kuzzle
   .collection('collection', 'index')
-  .scrollPromise(scrollId, "1m", options)
+  .scrollPromise(scrollId, {scroll: '1m'}, options)
   .then(searchResult => {
     searchResult.getDocuments().forEach(document => {
       console.log(document.toString());
@@ -1076,10 +1076,11 @@ kuzzle
 
 ```java
 Options opts = new Options();
+opts.setScroll("1m");
 
 kuzzle
   .collection("collection", "index")
-  .scroll(scrollId, "1m", opts, new ResponseListener<SearchResult>() {
+  .scroll(scrollId, opts, new ResponseListener<SearchResult>() {
     @Override
     public void onSuccess(SearchResult searchResult) {
       for (Document doc : searchResult.getDocuments()) {
@@ -1109,7 +1110,7 @@ $kuzzle = new Kuzzle('localhost');
 $dataCollection = $kuzzle->collection('collection', 'index');
 
 try {
-  $searchResult = $dataCollection->scroll($scrollId, '1m');
+  $searchResult = $dataCollection->scroll($scrollId, ['scroll': '1m']);
 
   // $searchResult instanceof SearchResult
   $searchResult->getTotal();
@@ -1143,7 +1144,6 @@ A scroll session is always initiated by a `search` action by using the `scroll` 
 | Arguments | Type | Description |
 |---------------|---------|----------------------------------------|
 | ``scrollId`` | string | The "scrollId" provided with the last scroll response or from the initial search request if it is the first scroll call |
-| ``scroll`` | string | Re-initializes the scroll session timeout to its value |
 | ``options`` | JSON object | Optional parameters |
 | ``callback`` | function | Callback handling the response |
 
@@ -1153,6 +1153,7 @@ Available options:
 | Option | Type | Description | Default |
 |---------------|---------|----------------------------------------|---------|
 | ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
+| ``scroll`` | string | Re-initializes the scroll session timeout to its value. If not defined, the scroll timeout is defaulted to a Kuzzle configuration | ``undefined`` |
 
 <aside class="notice">
   To get more information about scroll sessions, please refer to the <a href="/api-reference/#search">API reference documentation</a>.

--- a/sdk-reference/source/includes/_collection.md
+++ b/sdk-reference/source/includes/_collection.md
@@ -1110,7 +1110,7 @@ $kuzzle = new Kuzzle('localhost');
 $dataCollection = $kuzzle->collection('collection', 'index');
 
 try {
-  $searchResult = $dataCollection->scroll($scrollId, ['scroll': '1m']);
+  $searchResult = $dataCollection->scroll($scrollId, ['scroll' => '1m']);
 
   // $searchResult instanceof SearchResult
   $searchResult->getTotal();

--- a/sdk-reference/source/includes/_searchResult.md
+++ b/sdk-reference/source/includes/_searchResult.md
@@ -68,7 +68,7 @@ catch (ErrorException $e) {
 }
 ```
 
-### Document(collection, total, documents, aggregations, searchArgs, [previous])
+### Document(collection, total, documents, aggregations, options, filters, [previous])
 
 | Arguments | Type | Description |
 |---------------|---------|----------------------------------------|
@@ -76,8 +76,9 @@ catch (ErrorException $e) {
 | ``total`` | integer | The total number of results of the search/scroll request |
 | ``documents`` | Document[] | An array of instantiated Document objects |
 | ``aggregations`` | object | The result of an aggregation produced by a search request |
-| ``searchArgs`` | object | The arguments of the search/scroll request |
-| ``previous`` | SearchRequest | The previous SearchResult produced by a previous search/scroll request (see [getNext](#getnext)) |
+| ``options`` | object | The arguments of the search/scroll request |
+| ``filters`` | object | The filters of the search request |
+| ``previous`` | SearchRequest | The previous SearchResult produced by a previous search/scroll request (see [fetchNext](#fetchnext)) |
 
 **Note:** this constructor is meant to be called internally when retrieving results from a search or a scroll request.
 
@@ -89,7 +90,8 @@ catch (ErrorException $e) {
 | ``collection`` | Collection | The data collection associated to this document | get |
 | ``documents`` | Document[] | An array of instantiated Document objects | get |
 | ``fetchedDocument`` | number | Represents the offset of the last document in the current SearchResult set | get/set |
-| ``searchArgs`` | object | The arguments of the search/scroll request | get |
+| ``options`` | object | The arguments of the search/scroll request | get |
+| ``filters`` | object | The filters of the search request | get |
 | ``total`` | integer | The total number of results of the search/scroll request | get |
 
 ## Getters
@@ -99,7 +101,8 @@ catch (ErrorException $e) {
 | ``getCollection()`` | Collection | Returns the `collection` property value |
 | ``getDocuments()`` | Document[] | Returns the `documents` property value |
 | ``getFetchedDocument()`` | number | Returns the `fetchedDocument` property value |
-| ``getSearchArgs()`` | object | Returns the `searchArgs` property value |
+| ``getOptions()`` | object | Returns the `options` property value |
+| ``getFilters()`` | object | Returns the `filters` property value |
 | ``getTotal()`` | integer | Returns the `total` property value |
 
 
@@ -108,21 +111,23 @@ catch (ErrorException $e) {
 ```js
 // Using callbacks (NodeJS or Web Browser)
 searchResult.fetchNext(function (error, nextSearchResult) {
-  // called once the delete action has been completed
+  // called once the fetchNext action has been completed
+  // nextSearchResult is an instantiated SearchResult object
 });
 
 // Using promises (NodeJS)
-searchResult.fetchNextPromise().then(nextSearchResult => {
-  // called once the getNext action has been completed
-  // nextSearchResult is an instantiated SearchResult object
-});
+searchResult.fetchNextPromise()
+  .then(nextSearchResult => {
+    // called once the fetchNext action has been completed
+    // nextSearchResult is an instantiated SearchResult object
+  });
 ```
 
 ```java
-searchResult.getNext(new ResponseListener<SearchResult>() {
+searchResult.fetchNext(new ResponseListener<SearchResult>() {
   @Override
   public void onSuccess(SearchResult nextSearchResult) {
-    // called once the getNext action has been completed
+    // called once the fetchNext action has been completed
     // nextSearchResult is an instantiated SearchResult object
   }
 
@@ -145,16 +150,16 @@ use \Kuzzle\SearchResult;
  */
 
 try {
-  $nextSearchResult = $searchResult->getNext();
+  $nextSearchResult = $searchResult->fetchNext();
 } catch (ErrorException $e) {
     // Handle error
 }
 ```
 
-Fetches the next SearchResult, by triggering a new search/scroll request depending on the current SearchResult.
+Fetches the next SearchResult, by triggering a new search/scroll request depending on the options and filters of the SearchResult.
 
 If the previous request was a search or a scroll action which provided a `scroll` argument,
-`getNext` will use the `scrollId` retrieved from the current result to make a new scroll request.
+`fetchNext` will use the `scrollId` retrieved from the current result to make a new scroll request.
 
 If the previous request was a search action which provided `from` and `size` arguments,
-`getNext` will add `size` to `from` and make a new search request.
+`fetchNext` will add `size` to `from` and make a new search request.

--- a/sdk-reference/source/includes/_searchResult.md
+++ b/sdk-reference/source/includes/_searchResult.md
@@ -1,0 +1,160 @@
+# SearchResult
+
+This object is the result of a [search](#search) or a [scroll](#scroll) request, allowing to manipulate the result and do subsequent requests.
+
+## Constructors
+
+```js
+/*
+ Constructors are not exposed in the JS/Node SDK.
+ SearchResult objects are returned by search and scroll Collection methods.
+ */
+
+kuzzle.collection('collection', 'index').search({}, (error, searchResult) => {
+  // searchResult is a SearchResult object
+});
+```
+
+```java
+JSONObject filter = new JSONObject();
+
+kuzzle
+  .collection("collection", "index")
+  .search(filter, new ResponseListener<SearchResult>() {
+    @Override
+    public void onSuccess(SearchResult searchResult) {
+      for (Document doc : result.getDocuments()) {
+        // fetched documents
+      }
+ 
+      result.getTotal(); // returns the total number of documents returnable
+ 
+      result.getAggregations(): // returns a JSONObject representing the aggregations response
+    }
+ 
+    @Override
+    public void onError(JSONObject error) {
+      // Handle error
+    }
+  });
+```
+
+```php
+<?php
+
+use \Kuzzle\Kuzzle;
+
+
+$filters = (object) [];
+
+$kuzzle = new Kuzzle('localhost');
+$dataCollection = $kuzzle->collection('collection', 'index');
+
+try {
+  $searchResult = $dataCollection->search($filters);
+
+  // $searchResult instanceof SearchResult
+  $searchResult->getTotal();
+
+  foreach($searchResult->getDocuments() as $document) {
+    // $document instanceof Document
+  }
+
+  // return an array representing the aggregations response
+  $searchResult->getAggregations();
+}
+catch (ErrorException $e) {
+
+}
+```
+
+### Document(collection, total, documents, aggregations, searchArgs, [previous])
+
+| Arguments | Type | Description |
+|---------------|---------|----------------------------------------|
+| ``collection`` | Collection | An instantiated Collection object |
+| ``total`` | integer | The total number of results of the search/scroll request |
+| ``documents`` | Document[] | An array of instantiated Document objects |
+| ``aggregations`` | object | The result of an aggregation produced by a search request |
+| ``searchArgs`` | object | The arguments of the search/scroll request |
+| ``previous`` | SearchRequest | The previous SearchResult produced by a previous search/scroll request (see [getNext](#getnext)) |
+
+**Note:** this constructor is meant to be called internally when retrieving results from a search or a scroll request.
+
+## Properties
+
+| Property name | Type | Description | get/set |
+|--------------|--------|-----------------------------------|---------|
+| ``aggregations`` | object | The result of an aggregation produced by a search request | get |
+| ``collection`` | Collection | The data collection associated to this document | get |
+| ``documents`` | Document[] | An array of instantiated Document objects | get |
+| ``fetchedDocument`` | number | Represents the offset of the last document in the current SearchResult set | get/set |
+| ``searchArgs`` | object | The arguments of the search/scroll request | get |
+| ``total`` | integer | The total number of results of the search/scroll request | get |
+
+## Getters
+
+| Getter name | Type | Description |
+| ``getAggregations()`` | object | Returns the `aggregation` property value |
+| ``getCollection()`` | Collection | Returns the `collection` property value |
+| ``getDocuments()`` | Document[] | Returns the `documents` property value |
+| ``getFetchedDocument()`` | number | Returns the `fetchedDocument` property value |
+| ``getSearchArgs()`` | object | Returns the `searchArgs` property value |
+| ``getTotal()`` | integer | Returns the `total` property value |
+
+
+## fetchNext
+
+```js
+// Using callbacks (NodeJS or Web Browser)
+searchResult.fetchNext(function (error, nextSearchResult) {
+  // called once the delete action has been completed
+});
+
+// Using promises (NodeJS)
+searchResult.fetchNextPromise().then(nextSearchResult => {
+  // called once the getNext action has been completed
+  // nextSearchResult is an instantiated SearchResult object
+});
+```
+
+```java
+searchResult.getNext(new ResponseListener<SearchResult>() {
+  @Override
+  public void onSuccess(SearchResult nextSearchResult) {
+    // called once the getNext action has been completed
+    // nextSearchResult is an instantiated SearchResult object
+  }
+
+  @Override
+  public void onError(JSONObject error) {
+    // Handle error
+  }
+});
+```
+
+```php
+<?php
+
+use \Kuzzle\SearchResult;
+
+// ...
+
+/**
+ * @var $searchResult SearchResult
+ */
+
+try {
+  $nextSearchResult = $searchResult->getNext();
+} catch (ErrorException $e) {
+    // Handle error
+}
+```
+
+Fetches the next SearchResult, by triggering a new search/scroll request depending on the current SearchResult.
+
+If the previous request was a search or a scroll action which provided a `scroll` argument,
+`getNext` will use the `scrollId` retrieved from the current result to make a new scroll request.
+
+If the previous request was a search action which provided `from` and `size` arguments,
+`getNext` will add `size` to `from` and make a new search request.

--- a/sdk-reference/source/index.md
+++ b/sdk-reference/source/index.md
@@ -18,6 +18,7 @@ includes:
   - document
   - memoryStorage
   - room
+  - searchResult
   - security/security
   - security/role
   - security/profile


### PR DESCRIPTION
* Document the `SearchResult` object (constructor, properties, getters, method)

fix #18
