### PR TITLE
[HOTFIX] Update document:scroll API route

### DIFF
--- a/api-reference/source/includes/_documentController.md
+++ b/api-reference/source/includes/_documentController.md
@@ -442,18 +442,8 @@ with the value `wait_for` in order to wait for the document indexation (indexed 
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7512/_scroll/<scrollId>`
->**Method:** `POST`
->**Body:**
-
-<section class="http"></section>
-
-```litcoffee
-{
-  // The scroll parameter tells Elasticsearch to keep the search context open for another 1m.
-  "scroll": "1m"
-}
-```
+>**URL:** `http://kuzzle:7512/_scroll/<scrollId>[?scroll=<scroll ttl]`  
+>**Method:** `GET`  
 
 <section class="others"></section>
 
@@ -465,11 +455,10 @@ with the value `wait_for` in order to wait for the document indexation (indexed 
 {
   "controller": "document",
   "action": "scroll",
+  "scrollId": "<scrollId>",
 
-  "body": {
-    "scrollId": "<scrollId>"
-    // The scroll parameter tells Elasticsearch to keep the search context open for another 1m.
-    "scroll": "1m"
+  // Optional: time to live of the cursor
+  "scroll": "1m"
   }
 }
 ```


### PR DESCRIPTION
# Description 

Following https://github.com/kuzzleio/kuzzle/pull/709, update the `document:scroll` documentation with the following changes:

* HTTP: scroll is now accessible through a GET request
* Other protocols: update the way parameters are passed to Kuzzle
* The `scroll` argument is now optional
