### PR TITLE
Document the new ExternalServiceError object

### DIFF
--- a/plugin-reference/source/includes/_plugin-context.md
+++ b/plugin-reference/source/includes/_plugin-context.md
@@ -533,6 +533,16 @@ Used to notify about badly formed requests.
 var err = new context.errors.BadRequestError('error message');
 ```
 
+### `ExternalServiceError`
+
+**Status Code:** `500`
+
+Used when an external service answers to a request with an error other than a bad request or a service unavailable one.
+
+```js
+var err = new context.errors.ExternalServiceError('error message');
+```
+
 ### ForbiddenError`
 
 **Status Code:** `403`


### PR DESCRIPTION
# Description

Add an entry for the new `ExternalServiceError` object in the plugin context.

# Related issue

https://github.com/kuzzleio/kuzzle/issues/731
