### PR TITLE
Document the new "retryOnConflict" option

### DIFF
--- a/api-reference/source/includes/_documentController.md
+++ b/api-reference/source/includes/_documentController.md
@@ -1214,9 +1214,9 @@ with the value `wait_for` in order to wait for the document indexation (indexed 
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7512/<index>/<collection>/_mUpdate[?refresh=wait_for]`
->**Method:** `PUT`
->**Body:**
+>**URL:** `http://kuzzle:7512/<index>/<collection>/_mUpdate[?refresh=wait_for][&retryOnConflict=<retries>]`  
+>**Method:** `PUT`  
+>**Body:**  
 
 <section class="http"></section>
 
@@ -1286,6 +1286,7 @@ with the value `wait_for` in order to wait for the document indexation (indexed 
   "collection": "<collection>",
   "action": "mUpdate",
   ["refresh": "wait_for",]
+  ["retryOnConflict": <number of retries>,]
   "controller": "document",
   "requestId": "<unique request identifier>",
   "result": {
@@ -1330,12 +1331,15 @@ Returns a partial error (with status 206) if one or more documents can not be up
 Elastisearch 5.x and above only: The optional parameter `refresh` can be used
 with the value `wait_for` in order to wait for the document indexation (indexed documents are available for `search`).
 
+Conflicts may occur if the same document gets updated multiple times within a short time on a database cluster. When this happens, Kuzzle answers with an error that clients have to handle.  
+You may set the `retryOnConflict` optional argument with a positive integer, asking Kuzzle to retry updating the document that number of times before rejecting the request with an error.
+
 
 ## update
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7512/<index>/<collection>/<documentId>/_update[?refresh=wait_for]`  
+>**URL:** `http://kuzzle:7512/<index>/<collection>/<documentId>/_update[?refresh=wait_for][&retryOnConflict=<retries>]`  
 >**Method:** `PUT`  
 >**Body:**  
 

--- a/api-reference/source/includes/_documentController.md
+++ b/api-reference/source/includes/_documentController.md
@@ -1335,9 +1335,9 @@ with the value `wait_for` in order to wait for the document indexation (indexed 
 
 <section class="http"></section>
 
->**URL:** `http://kuzzle:7512/<index>/<collection>/<documentId>/_update[?refresh=wait_for]`
->**Method:** `PUT`
->**Body:**
+>**URL:** `http://kuzzle:7512/<index>/<collection>/<documentId>/_update[?refresh=wait_for]`  
+>**Method:** `PUT`  
+>**Body:**  
 
 <section class="http"></section>
 
@@ -1362,6 +1362,7 @@ with the value `wait_for` in order to wait for the document indexation (indexed 
   "controller": "document",
   "action": "update",
   ["refresh": "wait_for",]
+  ["retryOnConflict": <number of retries>,]
   // The document id you provided or that was generated at document creation.
   // it is also the one returned during a search query.
   "_id": "<documentId>"
@@ -1398,6 +1399,9 @@ Only documents in the persistent data storage layer can be updated.
 
 Elastisearch 5.x and above only: The optional parameter `refresh` can be used
 with the value `wait_for` in order to wait for the document indexation (indexed documents are available for `search`).
+
+Conflicts may occur if the same document gets updated multiple times within a short time on a database cluster. When this happens, Kuzzle answers with an error that clients have to handle.  
+You may set the `retryOnConflict` optional argument with a positive integer, asking Kuzzle to retry updating the document that number of times before rejecting the request with an error.
 
 
 ## validate

--- a/sdk-reference/source/includes/_collection.md
+++ b/sdk-reference/source/includes/_collection.md
@@ -1545,7 +1545,7 @@ Available options:
 | ``users`` | string | Filter notifications fired upon a user entering the room (user: ``in``), leaving the room (user: ``out``), or both (user: ``all``). Setting this variable to ``none`` prevents receiving these notifications | ``none`` |
 
 The `options` object is directly passed to the Room constructor.
-See the [Room object](#room) documentation for more information about these options and notifications. 
+See the [Room object](#room) documentation for more information about these options and notifications.
 
 ### Return value
 
@@ -1730,6 +1730,7 @@ Available options:
 | ``metadata`` | JSON object | Additional information passed to notifications to other users | ``null`` |
 | ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
 | ``refresh`` | string | If set to ``wait_for``, Kuzzle will wait the persistence layer indexation to return (available with Elasticsearch 5.x and above) | ``undefined`` |
+| `retryOnConflict` | int | Number of retries to attempt before rejecting this update because of a cluster sync conflict | `0` |
 
 ### Return value
 


### PR DESCRIPTION
# Description

Document support for the new `retryOnConflict` optional argument to `document:update` API route, and to `collection.updateDocument` SDK methods.

# Related issue

https://github.com/kuzzleio/kuzzle/issues/730
