### PR TITLE
Update plugin documentation with new strategy registration method

### DIFF
--- a/plugin-reference/source/includes/_creating-plugins.md
+++ b/plugin-reference/source/includes/_creating-plugins.md
@@ -348,10 +348,10 @@ function MyAuthenticationPlugin () {
   this.verify = function (request, username, password, callback) {
     // Code performing the necessary verifications
     if (success) {
-      done(null, this.context.accessors.users.load(username));
+      callback(null, this.context.accessors.users.load(username));
     }
     else {
-      done(null, false, 'Login failed');
+      callback(null, false, 'Login failed');
     }
   };
 };

--- a/plugin-reference/source/includes/_plugin-context.md
+++ b/plugin-reference/source/includes/_plugin-context.md
@@ -98,13 +98,13 @@ Here is the generic signature: `verify(request, ..., callback)`:
 ```js
 var LocalStrategy = require('passport-local').Strategy;
 
-function verify (request, username, password, done) {
+function verify (request, username, password, callback) {
   // verification code
   if (userVerified) {
-    done(null, userInformation);
+    callback(null, userInformation);
   }
   else {
-    done(null, false, 'Login failed');
+    callback(null, false, 'Login failed');
   }
 }
 


### PR DESCRIPTION
# Description

Replace the `passport.use` documentation with the `registerStrategy` one

# Related issue

https://github.com/kuzzleio/kuzzle/issues/746

# Documents

https://github.com/kuzzleio/kuzzle/pull/764
