### PR TITLE
Fix 138 partial errors

### DIFF
--- a/api-reference/source/includes/_bulkController.md
+++ b/api-reference/source/includes/_bulkController.md
@@ -1,17 +1,17 @@
 # ~ bulk controller
 
+<aside class="warning">
+The bulk operations only apply to the persistent data storage layer.
+You <strong>won't receive any real-time notfications</strong> on your document subcriptions
+even if some of the documents in the import match your subscription filters.
+</aside>
+
 A bulk import allows your application to perform multiple writing operations thanks to a single query.
 This is especially useful if you want to create a large number of documents. A bulk import will be
 a lot faster compared to creating them individually using `create` queries.
 
 For other queries, the syntax for bulk imports closely resembles the
 [ElasticSearch Bulk API](https://www.elastic.co/guide/en/elasticsearch/reference/5.x/docs-bulk.html).
-
-<aside class="warning">
-The bulk operations only apply to the persistent data storage layer.
-You <strong>won't receive any real-time notfications</strong> on your document subcriptions
-even if some of the documents in the import match your subscription filters.
-</aside>
 
 
 ## import
@@ -110,6 +110,7 @@ even if some of the documents in the import match your subscription filters.
 You can use the `bulk import` to save a list of documents in one specific `collection` in a specified `index`.  
 In such case, the `collection` in which the documents need to be inserted needs to be specified in the query.
 
+In case a subset of the queries sent within the request fail, the client will receive a <a href="#partialerror">PartialError</a> object.
 
 ### Performing a global bulk import
 

--- a/api-reference/source/includes/_documentController.md
+++ b/api-reference/source/includes/_documentController.md
@@ -744,7 +744,7 @@ Optional arguments:
 
 Creates new documents in the persistent data storage.
 
-Returns a partial error (with status 206) if one or more documents already exist.
+Returns a [partial error](#partialerror) (with status 206) if one or more documents creation fails.
 
 Elastisearch 5.x and above only: The optional parameter `refresh` can be used
 with the value `wait_for` in order to wait for the document indexation (indexed documents are available for `search`).
@@ -888,7 +888,7 @@ with the value `wait_for` in order to wait for the document indexation (indexed 
 
 Creates or replaces documents in the persistent data storage.
 
-Returns a partial error (with status 206) if one or more documents can not be created or replaced.
+Returns a [partial error](#partialerror) (with status 206) if one or more documents can not be created or replaced.
 
 
 ## mDelete
@@ -947,7 +947,7 @@ Returns a partial error (with status 206) if one or more documents can not be cr
 
 Deletes documents in the persistent data storage.
 
-Returns a partial error (with status 206) if one or more document can not be deleted.
+Returns a [partial error](#partialerror) (with status 206) if one or more document can not be deleted.
 
 Elastisearch 5.x and above only: The optional parameter `refresh` can be used
 with the value `wait_for` in order to wait for the document indexation (indexed documents are available for `search`).
@@ -1049,6 +1049,7 @@ Given `document ids`, retrieves the corresponding documents from the database.
 
 Only documents in the persistent data storage layer can be retrieved.
 
+Returns a [partial error](#partialerror) (with status 206) if one or more document can not be retrieved.
 
 ## mReplace
 
@@ -1189,7 +1190,7 @@ Only documents in the persistent data storage layer can be retrieved.
 
 Replaces documents in the persistent data storage.
 
-Returns a partial error (with status 206) if one or more documents can not be replaced.
+Returns a [partial error](#partialerror) (with status 206) if one or more documents can not be replaced.
 
 Elastisearch 5.x and above only: The optional parameter `refresh` can be used
 with the value `wait_for` in order to wait for the document indexation (indexed documents are available for `search`).

--- a/api-reference/source/includes/_errors.md
+++ b/api-reference/source/includes/_errors.md
@@ -1,0 +1,111 @@
+# Errors
+
+All errors received by Kuzzle clients are `Kuzzle errors`. 
+
+A `Kuzzle error` has the following properties:
+
+| property | type | description |
+| -------- | ---- | ----------- |
+| `status` | integer | HTTP like status code. In most cases, will be the same as the response one. |
+| `message` | text | Short description of the error |
+| `stack` | text | **Available in development mode only** - Kuzzle stack trace that generated the error |
+
+Clients can detect the error type based on their `status` and decide which action to take accordingly.
+
+## BadRequestError
+
+**status**: 400
+
+A `BadRequestError` is thrown if Kuzzle was unable to process the action due to a malformed request.
+
+`BadRequestError` objects can for instance be received if a mandatory parameter is missing or if its type is incorrect.
+ 
+## ExternalServiceError
+
+**status**: 500
+
+An `ExternalServiceError` is thrown if Kuzzle was unable to process the action due to some external service failure (i.e. database).
+
+## ForbiddenError
+
+**status**: 403
+
+A `ForbiddenError` is thrown if the requested action is not authorized for the current authenticated user.
+
+## GatewayTimeoutError
+
+**status**: 504
+
+A `GatewayTimeoutError` is thrown if Kuzzle is too long to respond.
+
+<aside class="warning">
+Receiving this error does not guarantee the original request was not processed, just that it was not processed _in time_.<br>
+Clients shall make some extra checks to verify if the original action was actually successful.
+</aside>
+
+## InternalError
+
+**status**: 500
+
+An `InternalError` is thrown if Kuzzle encountered a severe unknown error.
+
+## NotFoundError
+
+**status** 404
+
+A `NotFoundError` is thrown if the requested resource could not be found, like, for instance, when calling `document/get` on a non-existing id.
+
+<!---
+ParseError: not documented @TODO: remove its current usage by BadRequestError
+-->
+
+## PartialError
+
+**status**: 206
+
+A `PartialError` is thrown if Kuzzle was unable to process a subset of a multi-actions requests.
+
+A `PartialError` can be generated, for instance, if one or several queries inside a `bulk/import` request failed.
+
+The detail of each failure can be retrieved using the `errors` property of the error object.
+
+### Additional properties
+
+| property | type | description |
+| -------- | ---- | ----------- |
+| `count` | integer | number of failures encountered |
+| `errors` | array or `KuzzleError` objects | Detailed errors of the failed actions |
+
+## PluginImplementationError
+
+**status**: 500
+
+A `PluginImplementationError` is thrown if Kuzzle encountered a severe unknown error issued by a [plugin](../plugin-reference/).
+
+## PreconditionError
+
+**status**: 412
+
+A `PreconditionError` is thrown if Kuzzle was not able to process the request due to an invalid state.
+
+This error can for instance be generated when trying to create a document on a non-existing collection.
+
+## ServiceUnavailableError
+
+**status**: 503
+
+A `ServiceUnavailableError` can be sent by Kuzzle proxy if no Kuzzle instance is found to process the request.
+
+## SizeLimitError
+
+**status**: 413
+
+A `SizeLimitError` is thrown by Kuzzle if the request size exceeds the limits defined in the [proxy configuration](../guide/#configuring-kuzzle-proxy).
+
+## UnauthorizedError
+
+**status**: 401
+
+An `UnauthorizedError` is thrown by Kuzzle if the permissions could not be verified for the request.
+
+Typically, an `UnauthorizedError` will be generated for a restricted action if the client is not authentified yet.

--- a/api-reference/source/index.md
+++ b/api-reference/source/index.md
@@ -25,6 +25,7 @@ includes:
   - realtimeController
   - securityController
   - serverController
+  - errors
 
 search: true
 ---

--- a/api-reference/source/stylesheets/screen.css.scss
+++ b/api-reference/source/stylesheets/screen.css.scss
@@ -1277,6 +1277,10 @@ h3 .heading-links {
   color: #FFF;
   font-weight: 600;
 }
+.content aside.notice a:visited,
+.content aside.notice a {
+  color: $dark;
+}
 
 .content .panels {
   padding: 35px;


### PR DESCRIPTION
* Adds an `Errors` section to the API doc
* Documents the fact that bulk/import may return a `PartialError`
* Link references to `PartialErrors` to the new section