### PR TITLE
SDK Reference: make returned instantiated objects point to their related documentation

### DIFF
--- a/sdk-reference/source/includes/_collection.md
+++ b/sdk-reference/source/includes/_collection.md
@@ -104,7 +104,7 @@ catch (ErrorException $e) {
 }
 ```
 
-Creates a new `CollectionMapping` object, using its constructor.
+Creates a new [CollectionMapping](#collectionmapping) object, using its constructor.
 
 ### collectionMapping([mapping])
 
@@ -114,7 +114,7 @@ Creates a new `CollectionMapping` object, using its constructor.
 
 ### Return value
 
-Returns the newly created `CollectionMapping` object.
+Returns the newly created [CollectionMapping](#collectionmapping) object.
 
 ## count
 
@@ -364,7 +364,7 @@ catch (ErrorException $e) {
 }
 ```
 
-Create a new document in Kuzzle.
+Create a new document in Kuzzle and resolves to a [Document](#document) object.
 
 ### createDocument(Document, [options], [callback])
 
@@ -393,7 +393,7 @@ Returns the `Collection` object to allow chaining.
 
 ### Callback response
 
-Resolves to a `Document` object containing the newly created document.
+Resolves to a [Document](#document) object containing the newly created document.
 
 ## delete
 
@@ -589,7 +589,7 @@ catch (ErrorException $e) {
 }
 ```
 
-Creates a new `Document` object, using its constructor.
+Creates a new [Document](#document) object, using its constructor.
 
 ### document([id], [content])
 
@@ -600,7 +600,7 @@ Creates a new `Document` object, using its constructor.
 
 ### Return value
 
-Returns the newly created `Document` object.
+Returns the newly created [Document](#document) object.
 
 ## fetchDocument
 
@@ -658,7 +658,7 @@ catch (ErrorException $e) {
 }
 ```
 
-Retrieves a single stored document using its unique document ID.
+Retrieves a single stored document using its unique document ID, and returns it as a [Document](#document) object.
 
 ### fetchDocument(documentId, [options], callback)
 
@@ -678,7 +678,7 @@ Available options:
 
 ### Callback response
 
-Resolves to a `Document` object.
+Resolves to a [Document](#document) object.
 
 ## fetchAllDocuments
 
@@ -778,7 +778,7 @@ Available options:
 Resolves to an object containing:
 
 - the total number of retrieved documents
-- a `array` of `Document` objects
+- a `array` of [Document](#document) objects
 
 
 ## getMapping
@@ -835,7 +835,7 @@ catch (ErrorException $e) {
 }
 ```
 
-Retrieves the current mapping of this collection.
+Retrieves the current mapping of this collection as a [CollectionMapping](#collectionmapping) object.
 
 ### getMapping([options], callback)
 
@@ -853,7 +853,7 @@ Available options:
 
 ### Callback response
 
-Resolves to a `CollectionMapping` object.
+Resolves to a [CollectionMapping](#collectionmapping) object.
 
 ## publishMessage
 
@@ -893,7 +893,7 @@ catch (ErrorException $e) {
 }
 ```
 
-Publish a realtime message
+Publish a real-time message.
 
 ### publishMessage(Document, [options], [callback])
 
@@ -982,7 +982,7 @@ catch (ErrorException $e) {
 }
 ```
 
-Replace an existing document with a new one.
+Replace an existing document and returns the updated version of it as a [Document](#document) object.
 
 ### replaceDocument(documentId, content, [options], [callback])
 
@@ -1007,7 +1007,7 @@ Returns the `Collection` object to allow chaining.
 
 ### Callback response
 
-Resolves to an updated `Document` object.
+Resolves to an updated [Document](#document) object.
 
 ## room (property)
 
@@ -1051,7 +1051,7 @@ Room room = kuzzle.collection("collection", "index")
 // not implemented (this SDK uses HTTP and is thus stateless)
 ```
 
-Creates a new `Room` object, using its constructor.
+Creates a new [Room](#room) object, using its constructor.
 
 ### room([options])
 
@@ -1139,15 +1139,11 @@ catch (ErrorException $e) {
 }
 ```
 
-> Callback response:
-
-Resolves to an instantiated [SearchResult](#searchresult) object.
-
 <aside class="notice">
   There is a small delay between documents creation and their existence in our search layer, usually a couple of seconds. That means that a document that was just been created won't be returned by this function
 </aside>
 
-Returns the next page of the scroll session, and the `scrollId` to be used by the next `scroll` action.
+Returns a [SearchResult](#searchresult) object containing the next page of the scroll session, and the `scrollId` to be used by the next `scroll` action.  
 A scroll session is always initiated by a `search` action by using the `scroll` argument; more information below.
 
 
@@ -1172,7 +1168,6 @@ Available options:
 </aside>
 
 ### Callback response
-
 
 Resolves to an instantiated [SearchResult](#searchresult) object.
 
@@ -1355,10 +1350,6 @@ catch (ErrorException $e) {
 }
 ```
 
-> Callback response:
-
-Resolves to an instantiated [SearchResult](#searchresult) object.
-
 
 <aside class="notice">
   There is a small delay between documents creation and their existence in our search layer, usually a couple of seconds. That means that a document that was just been created won't be returned by this function
@@ -1389,7 +1380,6 @@ Available options:
 </aside>
 
 ### Callback response
-
 
 Resolves to an instantiated [SearchResult](#searchresult) object.
 
@@ -1723,7 +1713,7 @@ catch (ErrorException $e) {
 }
 ```
 
-Update parts of a document, by replacing some fields or adding new ones.
+Update parts of a document, by replacing some fields or adding new ones.  
 Note that you cannot remove fields this way: missing fields will simply be left unchanged.
 
 ### updateDocument(documentId, content, [options], [callback])
@@ -1750,4 +1740,4 @@ Returns the `Collection` object to allow chaining.
 
 ### Callback response
 
-Resolves to an up-to-date `Document` object.
+Resolves to an up-to-date [Document](#document) object.

--- a/sdk-reference/source/includes/_kuzzle.md
+++ b/sdk-reference/source/includes/_kuzzle.md
@@ -398,7 +398,7 @@ The ``index`` argument takes precedence over the default index.
 
 ### Return value
 
-Returns a `Collection` object.
+Returns a [Collection](#collection) object.
 
 ## connect
 
@@ -1556,7 +1556,7 @@ The `Kuzzle` object will unset the property `jwtToken` if the user is successful
 
 ## memoryStorage (property)
 
-A `MemoryStorage` singleton.
+A [MemoryStorage](#memorystorage) singleton.
 
 ## now
 
@@ -1914,7 +1914,7 @@ Returns the `Kuzzle` object to allow chaining.
 
 ## security (property)
 
-A `Security` singleton.
+A [Security](#security) singleton.
 
 ## setAutoRefresh
 
@@ -2317,4 +2317,4 @@ Retrieves current user object.
 
 ### Callback response
 
-An instantiated `User` object.
+An instantiated [User](#user) object.

--- a/sdk-reference/source/includes/_searchResult.md
+++ b/sdk-reference/source/includes/_searchResult.md
@@ -26,12 +26,12 @@ kuzzle
       for (Document doc : result.getDocuments()) {
         // fetched documents
       }
- 
+
       result.getTotal(); // returns the total number of documents returnable
- 
+
       result.getAggregations(): // returns a JSONObject representing the aggregations response
     }
- 
+
     @Override
     public void onError(JSONObject error) {
       // Handle error
@@ -72,9 +72,9 @@ catch (ErrorException $e) {
 
 | Arguments | Type | Description |
 |---------------|---------|----------------------------------------|
-| ``collection`` | Collection | An instantiated Collection object |
+| ``collection`` | Collection | An instantiated [Collection](#collection) object |
 | ``total`` | integer | The total number of results of the search/scroll request |
-| ``documents`` | Document[] | An array of instantiated Document objects |
+| ``documents`` | Document[] | An array of instantiated [Document](#document) objects |
 | ``aggregations`` | object | The result of an aggregation produced by a search request |
 | ``options`` | object | The arguments of the search/scroll request |
 | ``filters`` | object | The filters of the search request |
@@ -97,6 +97,7 @@ catch (ErrorException $e) {
 ## Getters
 
 | Getter name | Type | Description |
+|-------------|------|--------------------------------------------|
 | ``getAggregations()`` | object | Returns the `aggregation` property value |
 | ``getCollection()`` | Collection | Returns the `collection` property value |
 | ``getDocuments()`` | Document[] | Returns the `documents` property value |

--- a/sdk-reference/source/includes/security/_profile.md
+++ b/sdk-reference/source/includes/security/_profile.md
@@ -16,7 +16,7 @@ var profileDefinition = {
   ]
 };
 
-var role = kuzzle.security.profile('myprofile', profileDefinition);
+var profile = kuzzle.security.profile('myprofile', profileDefinition);
 ```
 
 ```java
@@ -513,6 +513,30 @@ profile.update(updateContent, new ResponseListener<Profile>() {
 
   }
 });
+```
+
+```php
+<?php
+
+use Kuzzle\Security\Profile;
+
+// ...
+
+/*
+ * @var $profile Profile
+ */
+$profileContent = [
+  'policies' => [
+    ['roleId' => 'myrole']
+  ]
+];
+
+try {
+  $profile->update($profileContent);
+}
+catch (ErrorException $e) {
+
+}
 ```
 
 Performs a partial content update on this object.

--- a/sdk-reference/source/includes/security/_security.md
+++ b/sdk-reference/source/includes/security/_security.md
@@ -167,7 +167,7 @@ Available options:
 
 ### Callback response
 
-Resolves to a `Role` object.
+Resolves to a [Role](#role) object.
 
 ## createProfile
 
@@ -295,7 +295,7 @@ Available options:
 
 ### Callback response
 
-Resolves to a `Profile` object.
+Resolves to a [Profile](#profile) object.
 
 
 ## createUser
@@ -354,7 +354,7 @@ JSONObject credentials = new JSONObject()
   // The "local" authentication strategy requires a password
   .put("password", "secret password")
   .put("lastLoggedIn", 1494411803);
-  
+
 newUser.put("credentials", credentials);
 
 Options opts = new Options().setReplaceIfExist(true);
@@ -437,7 +437,7 @@ Available options:
 
 ### Callback response
 
-Resolves to a `User` object.
+Resolves to a [User](#user) object.
 
 ## createRestrictedUser
 
@@ -473,7 +473,7 @@ kuzzle
 
 ```java
 JSONObject content = new JSONObject();
-  
+
 JSONObject newUser = new JSONObject().put("content", content);
 
 JSONObject credentials = new JSONObject()
@@ -481,7 +481,7 @@ JSONObject credentials = new JSONObject()
   // The "local" authentication strategy requires a password
   .put("password", "secret password")
   .put("lastLoggedIn", 1494411803));
-  
+
 newUser.put("credentials", credentials);
 
 Options opts = new Options().setReplaceIfExist(true);
@@ -533,7 +533,7 @@ catch (ErrorException $e) {
 }
 ```
 
-Create a new restricted user in Kuzzle.
+Create a new restricted user in Kuzzle.  
 This function allows anonymous users for instance to create a "restricted" user with predefined rights.
 
 <aside class="notice">
@@ -561,7 +561,7 @@ Available options:
 
 ### Callback response
 
-Resolves to a `User` object.
+Resolves to a [User](#user) object.
 
 
 ## deleteProfile
@@ -616,7 +616,13 @@ catch (ErrorException $e) {
 }
 ```
 
-Delete profile.
+> Callback response
+
+```json
+"deleted profile identifier"
+```
+
+Delete the provided profile.
 
 <aside class="notice">
 There is a small delay between profile deletion and their deletion in our search layer, usually a couple of seconds.
@@ -698,7 +704,13 @@ catch (ErrorException $e) {
 }
 ```
 
-Delete role.
+> Callback response
+
+```json
+"deleted role identifier"
+```
+
+Delete the provided role.
 
 <aside class="notice">
 There is a small delay between role deletion and their deletion in our search layer, usually a couple of seconds.
@@ -780,7 +792,13 @@ catch (ErrorException $e) {
 }
 ```
 
-Delete user.
+> Callback response
+
+```json
+"deleted user identifier"
+```
+
+Delete the provided user.
 
 <aside class="notice">
 There is a small delay between user deletion and their deletion in our search layer, usually a couple of seconds.
@@ -884,7 +902,7 @@ Available options:
 
 ### Callback response
 
-Resolves to a `Profile` object.
+Resolves to a [Profile](#profile) object.
 
 ## fetchRole
 
@@ -960,7 +978,7 @@ Available options:
 
 ### Callback response
 
-Resolves to a `Role` object.
+Resolves to a [Role](#role) object.
 
 ## fetchUser
 
@@ -1035,7 +1053,7 @@ Available options:
 
 ### Callback response
 
-Resolves to a `User` object.
+Resolves to a [User](#user) object.
 
 
 ## getUserRights
@@ -1133,7 +1151,8 @@ Resolves to a `JSON` object.
 ```js
 kuzzle.security.getMyRights((err, rights) => {
     if (!err) {
-        kuzzle.security.isActionAllowed(rights, 'read', 'get', 'index1', 'collection1');
+        // returns either "allowed", "denied" or "conditional"
+        var allowed = kuzzle.security.isActionAllowed(rights, 'read', 'get', 'index1', 'collection1');
     }
 });
 ```
@@ -1142,7 +1161,9 @@ kuzzle.security.getMyRights((err, rights) => {
 kuzzle.security.getMyRights(new ResponseListener<JSONArray>() {
     @Override
     public void onSuccess(JSONArray rights) {
-        Rights rights = kuzzle.security.isActionAllowed(rights, "read", "get", "index1", "collection1");
+        // Policies is an enum with the following properties:
+        // allowed, denied, conditional
+        Policies authorization = kuzzle.security.isActionAllowed(rights, "read", "get", "index1", "collection1");
     }
 
     @Override
@@ -1180,10 +1201,12 @@ catch (ErrorException $e) {
 }
 ```
 
-Tells whether an action is allowed, denied or conditional based on the rights provided as the first argument.
+Tells whether an action is allowed, denied or conditional based on the rights provided as the first argument:
+
 - `allowed` is returned when an action is authorized without condition
 - `conditional` is returned when the authorization depends on a closure
 - `denied` is returned when the action is forbidden
+
 An action is defined as a couple of action and controller (mandatory), plus an index and a collection(optional).
 
 <aside class="notice">
@@ -1270,7 +1293,7 @@ $profile = $security->profile($profileId, $profileDefinition);
 // $profile instanceof Profile
 ```
 
-Instantiate a new Profile object.
+Instantiate a new [Profile](#profile) object.
 
 ### profile(id, content)
 
@@ -1281,7 +1304,7 @@ Instantiate a new Profile object.
 
 ### Return value
 
-Returns the `Profile` object.
+Returns the new [Profile](#profile) object.
 
 
 ## role
@@ -1339,7 +1362,7 @@ $role = $security->role($roleId, $roleDefinition);
 // $role instanceof Role
 ```
 
-Instantiate a new `Role` object.
+Instantiate a new [Role](#role) object.
 
 ### role(id, content)
 
@@ -1350,7 +1373,7 @@ Instantiate a new `Role` object.
 
 ### Return value
 
-Returns the `Role` object.
+Returns the new [Role](#role) object.
 
 
 ## searchProfiles
@@ -1368,7 +1391,11 @@ var filters = {
 kuzzle
   .security
   .searchProfiles(filters, function(error, result) {
-    // result is a JSON Object
+    // result is a JSON Object with the following properties:
+    // {
+    //   total: <number of found profiles>,
+    //   documents: [<Profile object>, <Profile object>, ...]
+    // }
   });
 
 // Using promises (NodeJS)
@@ -1376,7 +1403,11 @@ kuzzle
   .security
   .searchProfilesPromise(filters)
   .then((result) => {
-    // result is a JSON Object
+    // result is a JSON Object with the following properties:
+    // {
+    //   total: <number of found profiles>,
+    //   documents: [<Profile object>, <Profile object>, ...]
+    // }
   });
 ```
 
@@ -1436,7 +1467,6 @@ try {
   $result = $security->searchProfiles($filters, $options);
 
   // $result instanceof ProfilesSearchResult
-
   foreach($result->getProfiles() as $profile) {
     // $profile instanceof Profile
   }
@@ -1452,7 +1482,7 @@ catch (ErrorException $e) {
 {
   "total": 124,
   "documents": [
-    // array of Profile
+    // array of Profile objects
   ]
 }
 ```
@@ -1483,7 +1513,7 @@ Available filters:
 
 ### Callback response
 
-Resolves to a JSON Object
+Resolves to a JSON Object containing the number of found profiles and an array of [Profile](#profile) objects.
 
 
 ## searchUsers
@@ -1513,7 +1543,11 @@ var filter = {
 kuzzle
   .security
   .searchUsers(filters, function(error, result) {
-    // result is a JSON Object
+    // result is a JSON Object with the following properties:
+    // {
+    //   total: <number of found profiles>,
+    //   documents: [<User object>, <User object>, ...]
+    // }
   });
 
 // Using promises (NodeJS)
@@ -1521,7 +1555,11 @@ kuzzle
   .security
   .searchUsersPromise(filters)
   .then((result) => {
-    // result is a JSON Object
+    // result is a JSON Object with the following properties:
+    // {
+    //   total: <number of found profiles>,
+    //   documents: [<User object>, <User object>, ...]
+    // }
   });
 ```
 
@@ -1639,7 +1677,7 @@ Available options:
 
 ### Callback response
 
-Resolves to a JSON Object
+Resolves to a JSON Object containing the total number of found users, and an array of [User](#user) objects.
 
 
 ## searchRoles
@@ -1657,7 +1695,11 @@ var filters = {
 kuzzle
   .security
   .searchRoles(filters, function(error, result) {
-    // result is a JSON Object
+    // result is a JSON Object with the following properties:
+    // {
+    //   total: <number of found profiles>,
+    //   documents: [<Role object>, <Role object>, ...]
+    // }
   });
 
 // Using promises (NodeJS)
@@ -1665,7 +1707,11 @@ kuzzle
   .security
   .searchRolesPromise(filters)
   .then((result) => {
-    // result is a JSON Object
+    // result is a JSON Object with the following properties:
+    // {
+    //   total: <number of found profiles>,
+    //   documents: [<Role object>, <Role object>, ...]
+    // }
   });
 ```
 
@@ -1765,7 +1811,7 @@ Available filters:
 
 ### Callback response
 
-Resolves to a JSON Object
+Resolves to a JSON Object containing the total number of found roles and an array of [Role](#role) objects.
 
 ## updateProfile
 
@@ -1780,7 +1826,7 @@ var newContent = {
 kuzzle
   .security
   .updateProfile("profile ID", newContent, function (err, updatedProfile) {
-
+    // "updatedProfile" is an instance of a Profile object
   });
 
 // Using promises (NodeJS)
@@ -1788,7 +1834,7 @@ kuzzle
   .security
   .updateProfilePromise("profile ID", newContent)
   .then(updatedProfile => {
-
+    // "updatedProfile" is an instance of a Profile object
   });
 ```
 
@@ -1884,7 +1930,7 @@ Returns the `Security` object to allow chaining.
 
 ### Callback response
 
-Resolves to an updated `Profile` object
+Resolves to an updated [Profile](#profile) object
 
 ## updateRole
 
@@ -1903,7 +1949,7 @@ var roleDefinition = {
 kuzzle
   .security
   .updateRole("role ID", roleDefinition, function (err, updatedRole) {
-
+    // "updatedRole" is an instance of a Role object
   });
 
 // Using promises (NodeJS)
@@ -1911,7 +1957,7 @@ kuzzle
   .security
   .updateRolePromise("profile ID", roleDefinition)
   .then(updatedRole => {
-
+    // "updatedRole" is an instance of a Role object
   });
 ```
 
@@ -1994,7 +2040,7 @@ Returns the `Security` object to allow chaining.
 
 ### Callback response
 
-Resolves to an updated `Role` object
+Resolves to an updated [Role](#role) object
 
 
 ## updateUser
@@ -2010,7 +2056,7 @@ var newContent = {
 kuzzle
   .security
   .updateUser("User ID", newContent, function (err, updatedUser) {
-
+    // "updatedUser" is an instance of a User object
   });
 
 // Using promises (NodeJS)
@@ -2018,7 +2064,7 @@ kuzzle
   .security
   .updateUserPromise("User ID", newContent)
   .then(updatedUser => {
-
+    // "updatedUser" is an instance of a User object
   });
 ```
 
@@ -2067,7 +2113,6 @@ catch (ErrorException $e) {
 }
 ```
 
-
 #### updateUser(id, content, [options], [callback])
 
 Performs a partial update on an existing user.
@@ -2091,7 +2136,7 @@ Returns the `Security` object to allow chaining.
 
 ### Callback response
 
-Resolves to an updated `User` object
+Resolves to an updated [User](#user) object
 
 ## user
 
@@ -2147,7 +2192,7 @@ $user = $security->user($kuid, $userDefinition);
 // $user instanceof User
 ```
 
-Instantiates a new User object.
+Instantiates a new [User](#user) object.
 
 ### user(id, content)
 
@@ -2158,4 +2203,4 @@ Instantiates a new User object.
 
 ### Return value
 
-Returns the `User` object.
+Returns the new [User](#user) object.


### PR DESCRIPTION
# Description

To make the SDK documentation clearer, all methods resolving to an instantiated object implemented by SDKs now have links pointing to their corresponding documentation

# Boyscout

* Fixed `SearchResults.fetchDocument` markdown table
* Add missing `profile.update` PHP code example
* Add explanation about enum/string results returned by the `security.isActionAllowed` method

# Fixed issue

#207 
