### PR TITLE
Add example to the `Profile.getPolicies()` method

### DIFF
--- a/src/sdk-reference/profile/get-policies.md
+++ b/src/sdk-reference/profile/get-policies.md
@@ -38,6 +38,30 @@ foreach($profile->getPolicies() as $policy) {
 }
 ```
 
+> Callback response
+
+```json
+[
+  {
+    "roleId": "<role name1>",
+    "restrictedTo": {
+      "index": "<some index>",
+      "collections": ["<collection1>", "<collection2>", "<...>"]
+    }
+  },
+  {
+    "roleId": "<role name2>"
+  },
+  {
+    "roleId": "<role name3>",
+    "restrictedTo": {
+      "index": "<some other index>",
+      "collections": ["<collection>"]
+    }
+  }
+]
+```
+
 Returns this profile associated role policies.
 
 ---


### PR DESCRIPTION
# Description

Add a callback resolution example to the `Profile.getPolicies()` method in the SDK Reference.

# Fixed issue

#280 
