### PR TITLE
Add a user authentication guide

### DIFF
--- a/src/api-documentation/controller-security/create-credentials.md
+++ b/src/api-documentation/controller-security/create-credentials.md
@@ -56,7 +56,7 @@ title: createCredentials
   "controller": "security",
   "action": "createCredentials",
   "strategy": "<strategy>",
-  "_id": "<kuid>",             
+  "_id": "<kuid>",
   "body": {
     "username": "MyUser",
     "password": "MyPassword"
@@ -70,8 +70,8 @@ title: createCredentials
 // example with a "local" authentication
 
 {
-  "status": 200,                     
-  "error": null,                     
+  "status": 200,
+  "error": null,
   "action": "createCredentials",
   "controller": "security",
   "_id": "<kuid>",
@@ -82,4 +82,4 @@ title: createCredentials
 }
 ```
 
-Create credentials of the specified `<strategy>` for the user [`<kuid>`]({{ site_base_path }}guide/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid). The credentials to send depends entirely on the authentication plugin and strategy you want to create credentials for.
+Create credentials of the specified `<strategy>` for the user [`<kuid>`]({{ site_base_path }}guide/essentials/user-authentication/#kuzzle-user-identifier-kuid). The credentials to send depends entirely on the authentication plugin and strategy you want to create credentials for.

--- a/src/api-documentation/controller-security/create-first-admin.md
+++ b/src/api-documentation/controller-security/create-first-admin.md
@@ -117,7 +117,7 @@ title: createFirstAdmin
 
 Creates the first admin `user` in Kuzzle's database layer. Does nothing if an admin user already exists.
 
-If an `_id` is provided in the query and if the user [`<kuid>`]({{ site_base_path }}guide/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid) already exists,
+If an `_id` is provided in the query and if the user [`<kuid>`]({{ site_base_path }}guide/essentials/user-authentication/#kuzzle-user-identifier-kuid) already exists,
 it will be replaced and its `profileIds` will be set to `["admin"]`. If not provided, the `_id` will be auto-generated.
 
 If the optional field `reset` is set to `true` (`1` with http),

--- a/src/api-documentation/controller-security/create-user.md
+++ b/src/api-documentation/controller-security/create-user.md
@@ -124,7 +124,7 @@ title: createUser
 
 Creates a new `user` in Kuzzle's database layer.
 
-If an `_id` is provided in the query and if a user [`<kuid>`]({{ site_base_path }}guide/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid) already exists, an error is returned.
+If an `_id` is provided in the query and if a user [`<kuid>`]({{ site_base_path }}guide/essentials/user-authentication/#kuzzle-user-identifier-kuid) already exists, an error is returned.
 If not provided, the `_id` will be auto-generated.
 
 Provided profile ids are used to set the permissions of the user.

--- a/src/api-documentation/controller-security/delete-credentials.md
+++ b/src/api-documentation/controller-security/delete-credentials.md
@@ -38,8 +38,8 @@ title: deleteCredentials
 
 ```javascript
 {
-  "status": 200,                     
-  "error": null,                     
+  "status": 200,
+  "error": null,
   "action": "deleteCredentials",
   "controller": "security",
   "_id": "<kuid>",
@@ -49,4 +49,4 @@ title: deleteCredentials
 }
 ```
 
-Delete credentials of the specified `<strategy>` for the user [`<kuid>`]({{ site_base_path }}guide/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid) .
+Delete credentials of the specified `<strategy>` for the user [`<kuid>`]({{ site_base_path }}guide/essentials/user-authentication/#kuzzle-user-identifier-kuid).

--- a/src/api-documentation/controller-security/delete-user.md
+++ b/src/api-documentation/controller-security/delete-user.md
@@ -38,8 +38,8 @@ title: deleteUser
 
 ```javascript
 {
-  "status": 200,                     
-  "error": null,                     
+  "status": 200,
+  "error": null,
   "result": {
     "_id": "<kuid>",                  // The kuzzle user identifier
   }
@@ -51,4 +51,4 @@ title: deleteUser
 }
 ```
 
-Given a `user id`, deletes the corresponding [`<kuid>`]({{ site_base_path }}guide/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid) from Kuzzle's database layer.
+Given a `user id`, deletes the corresponding [`<kuid>`]({{ site_base_path }}guide/essentials/user-authentication/#kuzzle-user-identifier-kuid) from Kuzzle's database layer.

--- a/src/api-documentation/controller-security/get-credentials.md
+++ b/src/api-documentation/controller-security/get-credentials.md
@@ -40,8 +40,8 @@ title: getCredentials
 // example with a "local" authentication
 
 {
-  "status": 200,                     
-  "error": null,                     
+  "status": 200,
+  "error": null,
   "action": "getCredentials",
   "controller": "security",
   "_id": "<kuid>",
@@ -52,4 +52,4 @@ title: getCredentials
 }
 ```
 
-Get credential information of the specified `<strategy>` for the user [`<kuid>`]({{ site_base_path }}guide/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid). Provided information completely depend of the strategy. The result can be an empty object.
+Get credential information of the specified `<strategy>` for the user [`<kuid>`]({{ site_base_path }}guide/essentials/user-authentication/#kuzzle-user-identifier-kuid). Provided information completely depend of the strategy. The result can be an empty object.

--- a/src/api-documentation/controller-security/get-user.md
+++ b/src/api-documentation/controller-security/get-user.md
@@ -37,8 +37,8 @@ title: getUser
 
 ```javascript
 {
-  "status": 200,                     
-  "error": null,                     
+  "status": 200,
+  "error": null,
   "index": "<index>",
   "collection": "<collection>",
   "controller": "security",
@@ -55,4 +55,4 @@ title: getUser
 ```
 
 
-Given a user [`<kuid>`]({{ site_base_path }}guide/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid), gets the matching user from Kuzzle's dabatase layer.
+Given a user [`<kuid>`]({{ site_base_path }}guide/essentials/user-authentication/#kuzzle-user-identifier-kuid), gets the matching user from Kuzzle's dabatase layer.

--- a/src/api-documentation/controller-security/has-credentials.md
+++ b/src/api-documentation/controller-security/has-credentials.md
@@ -38,8 +38,8 @@ title: hasCredentials
 
 ```javascript
 {
-  "status": 200,                     
-  "error": null,                     
+  "status": 200,
+  "error": null,
   "action": "hasCredentials",
   "controller": "security",
   "_id": "<kuid>",
@@ -47,4 +47,4 @@ title: hasCredentials
 }
 ```
 
-Check the existence of the specified `<strategy>`'s credentials for the user [`<kuid>`]({{ site_base_path }}guide/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid).
+Check the existence of the specified `<strategy>`'s credentials for the user [`<kuid>`]({{ site_base_path }}guide/essentials/user-authentication/#kuzzle-user-identifier-kuid).

--- a/src/api-documentation/controller-security/m-delete-users.md
+++ b/src/api-documentation/controller-security/m-delete-users.md
@@ -48,8 +48,8 @@ title: mDeleteUsers
 
 ```javascript
 {
-  "status": 200,                     
-  "error": null,                     
+  "status": 200,
+  "error": null,
   "action": "mDeleteUsers",
   "controller": "security",
   "requestId": "<unique request identifier>",
@@ -61,4 +61,4 @@ title: mDeleteUsers
 }
 ```
 
-Deletes a list of `users` objects from Kuzzle's database layer given a list of [`<kuids>`]({{ site_base_path }}guide/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid).
+Deletes a list of `users` objects from Kuzzle's database layer given a list of [`<kuids>`]({{ site_base_path }}guide/essentials/user-authentication/#kuzzle-user-identifier-kuid).

--- a/src/api-documentation/controller-security/update-credentials.md
+++ b/src/api-documentation/controller-security/update-credentials.md
@@ -69,8 +69,8 @@ title: updateCredentials
 // example with a "local" authentication
 
 {
-  "status": 200,                     
-  "error": null,                     
+  "status": 200,
+  "error": null,
   "action": "updateCredentials",
   "controller": "security",
   "_id": "<kuid>",
@@ -81,4 +81,4 @@ title: updateCredentials
 }
 ```
 
-Updates credentials of the specified `<strategy>` for the user [`<kuid>`]({{ site_base_path }}guide/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid). The credentials to send depends entirely on the authentication plugin and strategy you want to create credentials for.
+Updates credentials of the specified `<strategy>` for the user [`<kuid>`]({{ site_base_path }}guide/essentials/user-authentication/#kuzzle-user-identifier-kuid). The credentials to send depends entirely on the authentication plugin and strategy you want to create credentials for.

--- a/src/api-documentation/controller-security/update-user.md
+++ b/src/api-documentation/controller-security/update-user.md
@@ -66,4 +66,4 @@ title: updateUser
 }
 ```
 
-Given a [`<kuid>`]({{ site_base_path }}guide/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid), updates the matching User object in Kuzzle's database layer.
+Given a [`<kuid>`]({{ site_base_path }}guide/essentials/user-authentication/#kuzzle-user-identifier-kuid), updates the matching User object in Kuzzle's database layer.

--- a/src/api-documentation/controller-security/validate-credentials.md
+++ b/src/api-documentation/controller-security/validate-credentials.md
@@ -71,8 +71,8 @@ title: validateCredentials
 // example with a "local" authentication
 
 {
-  "status": 200,                     
-  "error": null,                     
+  "status": 200,
+  "error": null,
   "action": "validateCredentials",
   "controller": "security",
   "_id": "<kuid>",
@@ -83,4 +83,4 @@ title: validateCredentials
 }
 ```
 
-Validate credentials of the specified `<strategy>` for the user [`<kuid>`]({{ site_base_path }}guide/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid). `result` is true if provided credentials are valid; an error is triggered otherwise. This route does not actually create or modify the user credentials. The credentials to send depends entirely on the authentication plugin and strategy you want to create credentials for.
+Validate credentials of the specified `<strategy>` for the user [`<kuid>`]({{ site_base_path }}guide/essentials/user-authentication/#kuzzle-user-identifier-kuid). `result` is true if provided credentials are valid; an error is triggered otherwise. This route does not actually create or modify the user credentials. The credentials to send depends entirely on the authentication plugin and strategy you want to create credentials for.

--- a/src/guide/essentials/security.md
+++ b/src/guide/essentials/security.md
@@ -1,11 +1,11 @@
 ---
 layout: full.html
 algolia: true
-title: Security
+title: Security configuration
 order: 700
 ---
 
-# Security
+# Security configuration
 
 Kuzzle provides a full set of functionalities to finely define the permissions for your data.
 
@@ -13,26 +13,11 @@ Kuzzle provides a full set of functionalities to finely define the permissions f
 
 ## Fresh installation default rights.
 
-When installing Kuzzle for the very first time, no default user is created and the Anonymous user is allowed to perform any action on the data. The only restriction is on the internal data storage used by Kuzzle to store its configuration.
+When installing Kuzzle for the very first time, no default user is created and anonymous users (i.e. unauthenticated users) have administrator privileges.
 
-Once a first admin user is created, either via the [Kuzzle Back Office]({{ site_base_path }}guide/essentials/running-backoffice/#create-an-admin-account ) or the [CLI]({{ site_base_path }}guide/essentials/cli/#createfirstadmin), the Anonymous permissions are dropped.
+The first action to perform to secure your Kuzzle server is to create an administrator account, either via the [Kuzzle Back Office]({{ site_base_path }}guide/essentials/running-backoffice/#create-an-admin-account ) or the [CLI]({{ site_base_path }}guide/essentials/cli/#createfirstadmin).  
 
-You can then use the Back Office to administrate your user rights.
-
----
-
-## Authentication
-
-The first step to secure your data is to be able to identify your users.
-Kuzzle ships by default with a local login/password strategy.
-
-If the "local" strategy (i.e. storing the users' credentials in the local database) doesn't fit your needs, you can use the [Oauth authentication plugin](https://github.com/kuzzleio/kuzzle-plugin-auth-passport-oauth), or develop your own (see [Plugin documentation]({{ site_base_path }}plugins-reference/plugins-features/adding-authentication-strategy) for more details).
-
-If the authentication request identifies an existing user, Kuzzle generates a [JSON Web Token](https://tools.ietf.org/html/rfc7519) that must be [appended to all the subsequent requests]({{ site_base_path }}api-documentation/query-syntax/authorization-token/#authorization-token).
-
-<aside class="notice">
-More information on the login process <a href="{{ site_base_path }}api-documentation/controller-auth/login">here</a>.
-</aside>
+Doing so, you are given the possibility to drop almost all rights for anonymous users, securing your installation. You can then use the Back-Office (or the Kuzzle API) to create new users and to administrate their rights.
 
 ---
 

--- a/src/guide/essentials/user-authentication.md
+++ b/src/guide/essentials/user-authentication.md
@@ -1,0 +1,81 @@
+---
+layout: full.html
+algolia: true
+title: User authentication
+order: 750
+---
+
+# User authentication
+
+Once [roles and profiles]({{ site_base_path }}guide/essentials/security) have been set, you can create users and allow them to authenticate themselves in different ways.
+
+---
+
+## Authentication strategy
+
+An authentication strategy is a mean for users to authenticate themselves to Kuzzle. There are many ways to do it: OAuth (facebook, google, github, ...), kerberos, salesforce, and many, many others.  
+Kuzzle is able to support multiple authentication strategies, and users may have multiple ways to authenticate themselves.
+
+By default, Kuzzle is shipped with the `local` strategy, which is a simple but secure login/password authentication strategy.
+
+If this strategy doesn't fit your needs, you can use the [Oauth authentication plugin](https://github.com/kuzzleio/kuzzle-plugin-auth-passport-oauth), or you can develop your own strategy (see [Plugin documentation]({{ site_base_path }}plugins-reference/plugins-features/adding-authentication-strategy) for more details).
+
+---
+
+## Credentials
+
+A user's credentials are simply a list of allowed authentication strategies *for this user*, with this user's personal informations attached to each strategy.
+
+For instance, consider a Kuzzle server having the following available strategies: local, facebook, azure, saml and twitter.
+If a user registered to this Kuzzle with, say, facebook and twitter, then their credentials may look like this:
+
+```json
+{
+  "facebook": {
+    "kuid": "<Kuzzle Unique User Identifier>",
+    "login": "<login name>",
+    "email": "johndoe@foobar.qux"
+  },
+  "twitter": {
+    "kuid": "<Kuzzle Unique User Identifier>",
+    "login": "<login name>",
+    "avatar_url": "http://..."
+  }
+}
+```
+
+You may have noticed the presence of a `kuid` field in both credentials. More explanation about that field in the following chapters.
+
+---
+
+## User creation
+
+Users can be created either using the [back-office]({{ site_base_path }}guide/essentials/running-backoffice), [Kuzzle API]({{ site_base_path }}api-documentation/controller-security/create-user/), or a [Kuzzle SDK]({{ site_base_path }}sdk-reference/security/create-user/).
+
+When creating a user, you have to assign one or more [profiles]({{ site_base_path }}guide/essentials/security/#profile-definition) to it, defining its permissions.
+
+You may also provide:
+
+* A list of [credentials]({{ site_base_path }}guide/essentials/user-authentication/#credentials). If no credentials are provided, then this user cannot [log in]({{ site_base_path }}api-documentation/controller-auth/login/)
+* Additional user global informations. Those can be anything, from a lastname to a list of hobbies. There is no limitation, and these informations are global to this user, meaning that these are not linked to a particular authentication strategy
+
+---
+
+## Kuzzle User Identifier (kuid)
+
+When a user is created, Kuzzle assigns a random unique identifier to it, called the `kuid`.  
+This unique identifier is then provided to authentication plugins when new credentials are added to the user. It's the responsibility of authentication plugins to link their own user identifier (be it a login, email or whatever) to the corresponding `kuid`.
+
+This system allows a user to log in to Kuzzle using different strategies and, potentially, different login identifiers, while still being considered as an unique entity by Kuzzle.
+
+If you're interested for a more in-depth explanation on how all of this work, then please check our [Kuzzle In-Depth Documentation]({{ site_base_path }}guide/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid).
+
+---
+
+## User authentication
+
+Once a user has been created, and configured with a list of profiles and credentials, then they can send [an authentication request]({{ site_base_path }}api-documentation/controller-auth/login) in order to log in to Kuzzle, selecting one of their allowed authentication strategies.
+
+If the authentication plugin accepts the request, then Kuzzle creates a [JSON Web Token](https://tools.ietf.org/html/rfc7519) and send it back to the user.
+
+This token must then be [appended to all subsequent requests]({{ site_base_path }}api-documentation/query-syntax/authorization-token/#authorization-token). 

--- a/src/guide/kuzzle-depth/roles-definitions.md
+++ b/src/guide/kuzzle-depth/roles-definitions.md
@@ -76,7 +76,7 @@ The [Request](https://github.com/kuzzleio/kuzzle-common-objects#request) object 
 
 ### $currentUserId
 
-The `$currentUserId` variable contains the current user [`<kuid>`]({{ site_base_path }}guide/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid). It is an alias for `request.context.token.userId`.
+The `$currentUserId` variable contains the current user [`<kuid>`]({{ site_base_path }}guide/essentials/user-authentication/#kuzzle-user-identifier-kuid). It is an alias for `request.context.token.userId`.
 
 ### args
 

--- a/src/sdk-reference/kuzzle/get-my-credentials.md
+++ b/src/sdk-reference/kuzzle/get-my-credentials.md
@@ -12,23 +12,23 @@ title: getMyCredentials
 
 ```js
 // Using callbacks (node.js or browser)
-kuzzle.getMyCredentials('local', function (err, res) {
-  console.log(res);     // {username: 'foo', kuid: '<kuid>'}
+kuzzle.getMyCredentials('local', function (error, credentials) {
+
 });
 
 // Using promises (node.js)
 kuzzle
-  .getMyCredentials('local')
-  .then(res => {
-    console.log(res);   // {username: 'foo', kuid: '<kuid>'}
+  .getMyCredentialsPromise('local')
+  .then(credentials => {
+
   });
 ```
 
 ```java
 kuzzle.getMyCredentials("local", new ResponseListener<JSONObject>() {
   @Override
-  public void onSuccess(JSONObject result) {
-    // result var contains the credentials
+  public void onSuccess(JSONObject credentials) {
+
   }
 
   @Override
@@ -43,12 +43,19 @@ kuzzle.getMyCredentials("local", new ResponseListener<JSONObject>() {
 use \Kuzzle\Kuzzle;
 
 $kuzzle = new Kuzzle('localhost');
-$result = $kuzzle->getMyCredentials('local');
-
-// $result = [username => 'foo', kuid => '<kuid>']
+$credentials = $kuzzle->getMyCredentials('local');
 ```
 
-Get credential information of the specified <strategy> for the current user. 
+> Callback response
+
+```json
+{
+  "username": "foo", 
+  "kuid": "<Kuzzle Unique User Identifier>"
+}
+```
+
+Get [credential information]({{ site_base_path }}guide/essentials/user-authentication/#credentials) for the current user.
 
 ---
 
@@ -72,4 +79,4 @@ Get credential information of the specified <strategy> for the current user.
 
 ## Callback response
 
-The response is a an object reflecting the credentials.
+The response is an object reflecting the credentials for the provided authentication strategy.


### PR DESCRIPTION
# Description

While fixing #269, I found that the guide lacked necessary explanations about user authentication.

* In the `Guide/Essentials` documentation section:
    * Rename the `Security` section to `Security Configuration`
  * Add a new `User authentication` section just after the `Security Configuration` one
  * Move, rework and rename the `Authentication` chapter from `Security Configuration` to `User authentication`
  * Add new chapters to `User authentication`, explaining the basis of credentials, user creations, the kuid (simplified version compared to the chapter in the `In Depth` section), and login process
* Update most of the existing links to the `In-Depth/kuid` chapter to the new one in `Essentials/User Authentication`, as most of the time, the simplified version is enough of an explanation
* Fix #269 by adding a response example and linking to the new `User Authentication/Credentials` documentation

# Fixed issue

#269 


