### PR TITLE
fix credentials exemple in security

### DIFF
--- a/src/sdk-reference/security/create-credentials.md
+++ b/src/sdk-reference/security/create-credentials.md
@@ -12,12 +12,13 @@ title: createCredentials
 
 ```js
 // Using callbacks (node.js or browser)
-kuzzle.createCredentials('local', 'kuid', {'username': 'foo'}, function (err, res) {
+kuzzle.security.createCredentials('local', 'kuid', {'username': 'foo'}, function (err, res) {
   console.log(res);     // {username: 'bar', kuid: '<kuid>'}
 });
 
 // Using promises (node.js)
 kuzzle
+  .security
   .createCredentials('local', 'kuid', {'username': 'foo'})
   .then(res => {
     console.log(res);   // {username: 'foo', kuid: '<kuid>'}
@@ -27,7 +28,7 @@ kuzzle
 ```java
 JSONObject credentials = new JSONObject().put("username", "bar");
 
-kuzzle.createCredentials("local", "kuid", credentials, new ResponseListener<JSONObject>() {
+kuzzle.security.createCredentials("local", "kuid", credentials, new ResponseListener<JSONObject>() {
   @Override
   public void onSuccess(JSONObject result) {
     // result var contains the new credentials and the kuid of the user
@@ -45,7 +46,7 @@ kuzzle.createCredentials("local", "kuid", credentials, new ResponseListener<JSON
 use \Kuzzle\Kuzzle;
 
 $kuzzle = new Kuzzle('localhost');
-$result = $kuzzle->createCredentials('local', 'kuid', ['username' => 'foo']);
+$result = $kuzzle->security->createCredentials('local', 'kuid', ['username' => 'foo']);
 
 // $result = [username => 'foo', kuid => '<kuid>']
 ```

--- a/src/sdk-reference/security/delete-credentials.md
+++ b/src/sdk-reference/security/delete-credentials.md
@@ -12,12 +12,13 @@ title: deleteCredentials
 
 ```js
 // Using callbacks (node.js or browser)
-kuzzle.deleteCredentials('local', 'kuid', function (err, res) {
+kuzzle.security.deleteCredentials('local', 'kuid', function (err, res) {
   console.log(res);     // {acknowledged: true}
 });
 
 // Using promises (node.js)
 kuzzle
+  .security
   .deleteCredentials('local', 'kuid')
   .then(res => {
     console.log(res);   // {acknowledged: true}
@@ -25,7 +26,7 @@ kuzzle
 ```
 
 ```java
-kuzzle.deleteCredentials("local", "kuid", new ResponseListener<JSONObject>() {
+kuzzle.security.deleteCredentials("local", "kuid", new ResponseListener<JSONObject>() {
   @Override
   public void onSuccess(JSONObject result) {
     // result var contains the query status
@@ -43,7 +44,7 @@ kuzzle.deleteCredentials("local", "kuid", new ResponseListener<JSONObject>() {
 use \Kuzzle\Kuzzle;
 
 $kuzzle = new Kuzzle('localhost');
-$result = $kuzzle->deleteCredentials('local', 'kuid');
+$result = $kuzzle->security->deleteCredentials('local', 'kuid');
 
 // $result = [acknowledged => true]
 ```

--- a/src/sdk-reference/security/get-all-credential-fields.md
+++ b/src/sdk-reference/security/get-all-credential-fields.md
@@ -12,12 +12,13 @@ title: getAllCredentialFields
 
 ```js
 // Using callbacks (node.js or browser)
-kuzzle.getAllCredentialFields(function (err, res) {
+kuzzle.security.getAllCredentialFields(function (err, res) {
   console.log(res);     // { local: ['username', 'kuid']}
 });
 
 // Using promises (node.js)
 kuzzle
+  .security
   .getAllCredentialFields()
   .then(res => {
     console.log(res);   // { local: ['username', 'kuid']}
@@ -25,7 +26,7 @@ kuzzle
 ```
 
 ```java
-kuzzle.getAllCredentialFields(new ResponseListener<JSONObject>() {
+kuzzle.security.getAllCredentialFields(new ResponseListener<JSONObject>() {
   @Override
   public void onSuccess(JSONObject result) {
     // result var contains the credentials per strategy
@@ -43,7 +44,7 @@ kuzzle.getAllCredentialFields(new ResponseListener<JSONObject>() {
 use \Kuzzle\Kuzzle;
 
 $kuzzle = new Kuzzle('localhost');
-$result = $kuzzle->getAllCredentialFields();
+$result = $kuzzle->security->getAllCredentialFields();
 
 // $result = [local => [username, kuid]]
 ```

--- a/src/sdk-reference/security/get-credentials-fields.md
+++ b/src/sdk-reference/security/get-credentials-fields.md
@@ -12,12 +12,13 @@ title: getCredentialFields
 
 ```js
 // Using callbacks (node.js or browser)
-kuzzle.getCredentialFields('local', function (err, res) {
+kuzzle.security.getCredentialFields('local', function (err, res) {
   console.log(res);     // ['username', 'kuid']
 });
 
 // Using promises (node.js)
 kuzzle
+  .security
   .getCredentialFields('local')
   .then(res => {
     console.log(res);   // ['username', 'kuid']
@@ -25,7 +26,7 @@ kuzzle
 ```
 
 ```java
-kuzzle.getCredentialFields("local", new ResponseListener<JSONArray>() {
+kuzzle.security.getCredentialFields("local", new ResponseListener<JSONArray>() {
   @Override
   public void onSuccess(JSONArray result) {
     // result var contains the credentials
@@ -43,7 +44,7 @@ kuzzle.getCredentialFields("local", new ResponseListener<JSONArray>() {
 use \Kuzzle\Kuzzle;
 
 $kuzzle = new Kuzzle('localhost');
-$result = $kuzzle->getCredentialFields('local');
+$result = $kuzzle->security->getCredentialFields('local');
 
 // $result = [username, kuid]
 ```

--- a/src/sdk-reference/security/get-credentials.md
+++ b/src/sdk-reference/security/get-credentials.md
@@ -12,12 +12,13 @@ title: getCredentials
 
 ```js
 // Using callbacks (node.js or browser)
-kuzzle.getCredentials('local', 'kuid', function (err, res) {
+kuzzle.security.getCredentials('local', 'kuid', function (err, res) {
   console.log(res);     // {username: 'foo', kuid: '<kuid>'}
 });
 
 // Using promises (node.js)
 kuzzle
+  .security
   .getCredentials('local', 'kuid')
   .then(res => {
     console.log(res);   // {username: 'foo', kuid: '<kuid>'}
@@ -25,7 +26,7 @@ kuzzle
 ```
 
 ```java
-kuzzle.getCredentials("local", "kuid", new ResponseListener<JSONObject>() {
+kuzzle.security.getCredentials("local", "kuid", new ResponseListener<JSONObject>() {
   @Override
   public void onSuccess(JSONObject result) {
     // result var contains the credentials
@@ -43,7 +44,7 @@ kuzzle.getCredentials("local", "kuid", new ResponseListener<JSONObject>() {
 use \Kuzzle\Kuzzle;
 
 $kuzzle = new Kuzzle('localhost');
-$result = $kuzzle->getCredentials('local', 'kuid');
+$result = $kuzzle->security->getCredentials('local', 'kuid');
 
 // $result = [username => 'foo', kuid => '<kuid>']
 ```

--- a/src/sdk-reference/security/has-credentials.md
+++ b/src/sdk-reference/security/has-credentials.md
@@ -12,12 +12,13 @@ title: hasCredentials
 
 ```js
 // Using callbacks (node.js or browser)
-kuzzle.hasCredentials('local', 'kuid', function (err, res) {
+kuzzle.security.hasCredentials('local', 'kuid', function (err, res) {
   console.log(res);     // true or false
 });
 
 // Using promises (node.js)
 kuzzle
+  .security
   .hasCredentials('local', 'kuid')
   .then(res => {
     console.log(res);   // true or false
@@ -25,7 +26,7 @@ kuzzle
 ```
 
 ```java
-kuzzle.hasCredentials("local", "kuid", new ResponseListener<JSONObject>() {
+kuzzle.security.hasCredentials("local", "kuid", new ResponseListener<JSONObject>() {
   @Override
   public void onSuccess(JSONObject result) {
     // result var contains either true or false
@@ -43,7 +44,7 @@ kuzzle.hasCredentials("local", "kuid", new ResponseListener<JSONObject>() {
 use \Kuzzle\Kuzzle;
 
 $kuzzle = new Kuzzle('localhost');
-$result = $kuzzle->hasCredentials('local', 'kuid');
+$result = $kuzzle->security->hasCredentials('local', 'kuid');
 
 // $result = true or false
 ```

--- a/src/sdk-reference/security/update-credentials.md
+++ b/src/sdk-reference/security/update-credentials.md
@@ -12,12 +12,13 @@ title: updateCredentials
 
 ```js
 // Using callbacks (node.js or browser)
-kuzzle.updateCredentials('local', 'kuid', {'username': 'foo'}, function (err, res) {
+kuzzle.security.updateCredentials('local', 'kuid', {'username': 'foo'}, function (err, res) {
   console.log(res);     // {username: 'bar', kuid: '<kuid>'}
 });
 
 // Using promises (node.js)
 kuzzle
+  .security
   .updateCredentials('local', 'kuid', {'username': 'foo'})
   .then(res => {
     console.log(res);   // {username: 'foo', kuid: '<kuid>'}
@@ -27,7 +28,7 @@ kuzzle
 ```java
 JSONObject credentials = new JSONObject().put("username", "bar");
 
-kuzzle.updateCredentials("local", "kuid", credentials, new ResponseListener<JSONObject>() {
+kuzzle.security.updateCredentials("local", "kuid", credentials, new ResponseListener<JSONObject>() {
   @Override
   public void onSuccess(JSONObject result) {
     // result var contains the updated credentials and the kuid of the user
@@ -45,7 +46,7 @@ kuzzle.updateCredentials("local", "kuid", credentials, new ResponseListener<JSON
 use \Kuzzle\Kuzzle;
 
 $kuzzle = new Kuzzle('localhost');
-$result = $kuzzle->updateCredentials('local', 'kuid', ['username' => 'foo']);
+$result = $kuzzle->security->updateCredentials('local', 'kuid', ['username' => 'foo']);
 
 // $result = [username => 'foo', kuid => '<kuid>']
 ```

--- a/src/sdk-reference/security/validate-credentials.md
+++ b/src/sdk-reference/security/validate-credentials.md
@@ -12,12 +12,13 @@ title: validateCredentials
 
 ```js
 // Using callbacks (node.js or browser)
-kuzzle.validateCredentials('local', 'kuid', {'username': 'foo'}, function (err, res) {
+kuzzle.security.validateCredentials('local', 'kuid', {'username': 'foo'}, function (err, res) {
   console.log(res);     // true or false
 });
 
 // Using promises (node.js)
 kuzzle
+  .security
   .validateCredentials('local', 'kuid', {'username': 'foo'})
   .then(res => {
     console.log(res);   // true or false
@@ -27,7 +28,7 @@ kuzzle
 ```java
 JSONObject credentials = new JSONObject().put("username", "bar");
 
-kuzzle.validateCredentials("local", "kuid", credentials, new ResponseListener<Boolean>() {
+kuzzle.security.validateCredentials("local", "kuid", credentials, new ResponseListener<Boolean>() {
   @Override
   public void onSuccess(Boolean result) {
     // result var contains either true or false
@@ -45,7 +46,7 @@ kuzzle.validateCredentials("local", "kuid", credentials, new ResponseListener<Bo
 use \Kuzzle\Kuzzle;
 
 $kuzzle = new Kuzzle('localhost');
-$result = $kuzzle->validateCredentials('local', 'kuid', ['username' => 'foo']);
+$result = $kuzzle->security->validateCredentials('local', 'kuid', ['username' => 'foo']);
 
 // $result = true or false
 ```


### PR DESCRIPTION
Fix exemple of all credentials related methods of the sdk in security. Missing .security eg:
kuzzle.validateCredentials instead of kuzzle.security.validateCredentials 