### PR TITLE
Fix plugin name example and update plugin code example to ES6

### DIFF
--- a/src/plugins-reference/plugins-features/adding-controllers.md
+++ b/src/plugins-reference/plugins-features/adding-controllers.md
@@ -64,63 +64,65 @@ All action functions receive a [Request]({{ site_base_path }}plugins-reference/p
 ## TL;DR plugin skeleton
 
 ```javascript
-function ControllerPlugin () {
-  /*
-    This exposed "controllers" property tells Kuzzle that it needs to extend
-    its API with new controllers and actions.
+class ControllerPlugin {
+  constructor () {
+    /*
+      This exposed "controllers" property tells Kuzzle that it needs to extend
+      its API with new controllers and actions.
 
-    Here, we add a controller "newController", with 2 described actions:
-    "myAction" and "myOtherAction".
+      Here, we add a controller "newController", with 2 described actions:
+      "myAction" and "myOtherAction".
 
-    These actions point to functions exposed to Kuzzle by the plugin.
+      These actions point to functions exposed to Kuzzle by the plugin.
 
-    Any network protocol other than HTTP will be able to invoke this new
-    controller with the following JSON object:
+      Any network protocol other than HTTP will be able to invoke this new
+      controller with the following JSON object:
 
-    {
-      controller: '<plugin name>/newController',
-      action: 'myAction',
-      ...
-    }
-   */
-  this.controllers = {
-    newController: {
-      myAction: 'actionFunction',
-      myOtherAction: 'otherActionFunction'
-    }
-  };
+      {
+        controller: '<plugin name>/newController',
+        action: 'myAction',
+        ...
+      }
+     */
+    this.controllers = {
+      newController: {
+        myAction: 'actionFunction',
+        myOtherAction: 'otherActionFunction'
+      }
+    };
 
-  /*
-    We also want to expose our new controller to the HTTP protocol.
-    To do so, we give Kuzzle instructions on how we want to expose our
-    controller to HTTP.
-    Any parameter starting with a ':' in the URL will be made dynamic by Kuzzle.
+    /*
+      We also want to expose our new controller to the HTTP protocol.
+      To do so, we give Kuzzle instructions on how we want to expose our
+      controller to HTTP.
+      Any parameter starting with a ':' in the URL will be made dynamic by Kuzzle.
 
-    The first route exposes the following GET URL:
-      http://<kuzzle server>:<port>/_plugin/<plugin name>/foo/<dynamic value>
+      The first route exposes the following GET URL:
+        http://<kuzzle server>:<port>/_plugin/<plugin name>/foo/<dynamic value>
 
-    Kuzzle will provide the function 'actionFunction' with a Request object,
-    containing the "name" property: request.input.args.name = '<dynamic value>'
+      Kuzzle will provide the function 'actionFunction' with a Request object,
+      containing the "name" property: request.input.args.name = '<dynamic value>'
 
-    The second route exposes the following POST URL:
-      http://<kuzzle server>:<port>/_plugin/<plugin name>/bar
+      The second route exposes the following POST URL:
+        http://<kuzzle server>:<port>/_plugin/<plugin name>/bar
 
-    Kuzzle will provide the content body of the request in the Request object
-    passed to the function 'otherActionFunction', in the request.input.body
-    property
-   */
-  this.routes = [
-    {verb: 'get', url: '/foo/:name', controller: 'newController', action: 'myAction'},
-    {verb: 'post', url: '/bar', controller: 'newController', action: 'myOtherAction'}
-  ];
+      Kuzzle will provide the content body of the request in the Request object
+      passed to the function 'otherActionFunction', in the request.input.body
+      property
+     */
+    this.routes = [
+      {verb: 'get', url: '/foo/:name', controller: 'newController', action: 'myAction'},
+      {verb: 'post', url: '/bar', controller: 'newController', action: 'myOtherAction'}
+    ];
+  }
 
   /*
     Required plugin initialization function
     (see the "Plugin prerequisites" section)
    */
-  this.init = function (customConfig, context) {
+  init (customConfig, context) {
     // plugin initialization
-  };
+  }
 
   /*
     Implements the action newController/myAction
@@ -132,7 +134,7 @@ function ControllerPlugin () {
     See the "How plugins receive action arguments" chapter just below
     for more information.
    */
-  this.actionFunction = function (request) {
+  actionFunction (request) {
     // do action
 
     // optional: set network specific headers
@@ -143,7 +145,7 @@ function ControllerPlugin () {
 
     // Resolve with the result content. For instance:
     return Promise.resolve({acknowledge: true});
-  };
+  }
 
   /*
     Implements the action newController/myOtherAction
@@ -155,11 +157,10 @@ function ControllerPlugin () {
     See the "How plugins receive action arguments" chapter just below
     for more information.
    */
-  this.otherActionFunction = function (request) {
+  otherActionFunction (request) {
     // do action
     return Promise.resolve(/* result content */);
-
-  };
+  }
 }
 
 // Exports the plugin objects, allowing Kuzzle to instantiate it

--- a/src/plugins-reference/plugins-features/adding-hooks.md
+++ b/src/plugins-reference/plugins-features/adding-hooks.md
@@ -25,15 +25,18 @@ To achieve this, Kuzzle must specify a `threads` property in the [custom configu
 ```json
 {
   "plugins": {
-    "kuzzle-plugin-blabla": {
+    "kuzzle-plugin-worker": {
       "threads": 1
+    },
+    "kuzzle-plugin-listener": {
+      "threads": 0
     }
   }
 }
 ```
 
 If this number of threads is greater than 0, Kuzzle will launch the plugin on as many separate threads.  
-If there are more than 1 thread for that plugin, each time a listened event is fired, Kuzzle will pick one thread to notify using round-robin.
+If there are more than 1 thread for that plugin, each time a listened event is triggered, Kuzzle will pick one thread to notify using round-robin.
 
 <aside class="notice">
 As the Plugin is isolated in separated processes, the <a href="{{ site_base_path }}plugins-reference/plugins-context">plugin context</a> provided to worker plugins do not contain <code>accessors</code>
@@ -45,35 +48,37 @@ As the Plugin is isolated in separated processes, the <a href="{{ site_base_path
 ## TL;DR plugin skeleton
 
 ```javascript
-function HookPlugin () {
-  /*
-    This exposed "hooks" property tells Kuzzle that it needs to
-    attach the plugin function "myFunction" to the Kuzzle event
-    "eventType:hookName"
+class HookPlugin {
+  constructor () {
+    /*
+      This exposed "hooks" property tells Kuzzle that it needs to
+      attach the plugin function "myFunction" to the Kuzzle event
+      "eventType:hookName"
 
-    The function "myFunction" will be called whenever the event
-    "eventType:hookName" is fired.
-   */
-  this.hooks = {
-    'eventType:hookName': 'myFunction'
-  };
+      The function "myFunction" will be called whenever the event
+      "eventType:hookName" is triggered.
+     */
+    this.hooks = {
+      'eventType:hookName': 'myFunction'
+    };
+  }
 
   /*
    Required plugin initialization function
    (see the "Plugin prerequisites" section)
    */
-  this.init = function (customConfig, context) {
+  init (customConfig, context) {
     // initializes the plugin
-  };
+  }
 
   /*
    The configured function to call whenever the
-   "eventType:hookName" event is fired
+   "eventType:hookName" event is triggered
    */
-  this.myFunction = function (message, event) {
+  myFunction (message, event) {
     console.log(`Event ${event} triggered`);
     console.log(`Message received: ${message}`);
-  };
+  }
 }
 
 // Exports the plugin objects, allowing Kuzzle to instantiate it

--- a/src/plugins-reference/plugins-features/adding-pipes.md
+++ b/src/plugins-reference/plugins-features/adding-pipes.md
@@ -32,33 +32,35 @@ Pipes take a callback as their last parameter, which **must** be called at the e
 The following plugin example adds a `createdAt` attribute to all newly created documents:
 
 ```javascript
-function PipePlugin () {
-  /*
-    This exposed "pipes" property tells Kuzzle that it needs to
-    attach the plugin function "addCreatedAt" to the Kuzzle event
-    "document:beforeCreate"
+class PipePlugin {
+  constructor () {
+    /*
+      This exposed "pipes" property tells Kuzzle that it needs to
+      attach the plugin function "addCreatedAt" to the Kuzzle event
+      "document:beforeCreate"
 
-    The function "addCreatedAt" will be called whenever the event
-    "document:beforeCreate" is fired. Kuzzle will wait for
-    the function's result before continuing the request process
-   */
-  this.pipes = {
-    'document:beforeCreate': 'addCreatedAt'
-  };
+      The function "addCreatedAt" will be called whenever the event
+      "document:beforeCreate" is fired. Kuzzle will wait for
+      the function's result before continuing the request process
+     */
+    this.pipes = {
+      'document:beforeCreate': 'addCreatedAt'
+    };
+  }
 
   /*
     Required plugin initialization function
     (see the "Plugin prerequisites" section)
    */
-  this.init = function (customConfig, context) {
+  init (customConfig, context) {
     // Plugin initialization
-  };
+  }
 
   // Called whenever "document:beforeCreate" is fired
-  this.addCreatedAt = function (request, callback) {
+  addCreatedAt (request, callback) {
     request.input.body.createdAt = Date.now();
     callback(null, request);
-  };
+  }
 }
 
 // Exports the plugin objects, allowing Kuzzle to instantiate it

--- a/src/plugins-reference/plugins-features/adding-protocol.md
+++ b/src/plugins-reference/plugins-features/adding-protocol.md
@@ -45,21 +45,23 @@ Kuzzle Proxy expects Protocol Plugins to expose the following methods:
 ## TL;DR plugin skeleton
 
 ```javascript
-function ProtocolPlugin () {
-  this.context = null;
+class ProtocolPlugin {
+  constructor () {
+    this.context = null;
 
-  // Example on how to maintain client connections
-  this.clients = {};
-  this.connections = {};
+    // Example on how to maintain client connections
+    this.clients = {};
+    this.connections = {};
+  }
 
   /*
    Required plugin initialization function
    (see the "Plugin prerequisites" section)
   */
-  this.init = function (config, context) {
+  init (config, context) {
     // plugin initialization
     this.context = context;
-  };
+  }
 
   /*
    This function is only an example showing how to interact with
@@ -68,7 +70,7 @@ function ProtocolPlugin () {
    The way a protocol plugins handles clients closely depends on the
    implemented protocol.
    */
-  this.handleClient = function () {
+  handleClient () {
     // when a client connects
     this.on('onClientConnect', function (client) {
 
@@ -104,7 +106,7 @@ function ProtocolPlugin () {
       delete this.clients[connection.id];
       delete this.connections[client.id];
     });
-  };
+  }
 
   /*
    Invoked by Kuzzle when a "data.payload" payload needs to be
@@ -112,11 +114,11 @@ function ProtocolPlugin () {
 
    The payload is a Kuzzle response as a plain-old JSON object
   */
-  this.broadcast = function (data) {
+  broadcast (data) {
     data.channels.forEach(channel => {
       // sends data.payload to the channel
     });
-  };
+  }
 
   /*
    Invoked by Kuzzle when a "data.payload" payload needs to be
@@ -124,37 +126,37 @@ function ProtocolPlugin () {
 
    The payload is a Kuzzle response as a plain-old JSON object
   */
-  this.notify = function (data) {
+  notify (data) {
     data.channels.forEach(channel => {
       // sends "data.payload" to the connection "data.id" and to
       // the channel "channel"
     });
-  };
+  }
 
   /*
     Invoked by Kuzzle when the connection "data.id" joins the
     channel "data.channel"
    */
-  this.joinChannel = function (data) {
+  joinChannel (data) {
      // ...
-  };
+  }
 
   /*
     Invoked by Kuzzle when the connection "data.id" leaves the
     channel "data.channel"
    */
-  this.leaveChannel = function (data) {
+  leaveChannel (data) {
     // ...
-  };
+  }
 
   /*
     Invoked by Kuzzle when it needs to force-close a client connection
    */
-  this.disconnect = function (connectionId) {
+  disconnect (connectionId) {
     const client = this.clients[connectionId];
     // close the client connection
-  };
-};
+  }
+}
 
 // Exports the plugin objects, allowing Kuzzle to instantiate it
 module.exports = ProtocolPlugin;


### PR DESCRIPTION
# Description

Fix the unappropriate plugin name in the plugin listeners documentation.

Also update all plugin code examples to ES6 classes.

# Related issue

#253 
