### PR TITLE
Add documentation for specification routes in SDK

### DIFF
--- a/src/api-documentation/controller-collection/delete-specifications.md
+++ b/src/api-documentation/controller-collection/delete-specifications.md
@@ -9,7 +9,6 @@ title: deleteSpecifications
 
 # deleteSpecifications
 
-
 <blockquote class="js">
 <p>
 **URL:** `http://kuzzle:7512/<index>/<collection>/_specifications`  
@@ -42,11 +41,11 @@ title: deleteSpecifications
   "collection": "<collection>",
   "action": "deleteSpecifications",
   "controller": "collection",
-  "result": {}
+  "result": true
 }
 ```
 
 Deletes the validation specification set for the <index>/<collection>.
 It responds 200 even there where no validation specification manually set before.
 
-***Note:*** by default, an empty specification is implicitally applied to all collections which. In a way, "no specification set" means "all documents are valid". This is why, using this route when no specifications have been set before, does not produce an error.
+***Note:*** by default, an empty specification is implicitly applied to all collections which. In a way, "no specification set" means "all documents are valid". This is why, using this route when no specifications have been set before, does not produce an error.

--- a/src/api-documentation/controller-collection/delete-specifications.md
+++ b/src/api-documentation/controller-collection/delete-specifications.md
@@ -48,4 +48,4 @@ title: deleteSpecifications
 Deletes the validation specification set for the <index>/<collection>.
 It responds 200 even there where no validation specification manually set before.
 
-***Note:*** by default, an empty specification is implicitly applied to all collections which. In a way, "no specification set" means "all documents are valid". This is why, using this route when no specifications have been set before, does not produce an error.
+***Note:*** by default, an empty specification is implicitly applied to all collections. In a way, "no specification set" means "all documents are valid". This is why, using this route when no specifications have been set before, does not produce an error.

--- a/src/sdk-reference/collection/delete-specifications.md
+++ b/src/sdk-reference/collection/delete-specifications.md
@@ -14,7 +14,7 @@ title: deleteSpecifications
 // Deleting specifications using callbacks (NodeJS or Web Browser)
 kuzzle
   .collection('collection', 'index')
-  .deleteSpecifications(function (err, deleted) {
+  .deleteSpecifications(function (err, res) {
     // callback called once the delete action has been completed
   });
 
@@ -22,7 +22,7 @@ kuzzle
 kuzzle
   .collection('collection', 'index')
   .deleteSpecificationsPromise()
-  .then(deleted => {
+  .then(res => {
     // promises resolved once the delete action has been completed
   });
 ```
@@ -31,9 +31,9 @@ kuzzle
 // Deleting one document
 kuzzle
   .collection("collection", "index")
-  .deleteSpecifications(new ResponseListener<Boolean>() {
+  .deleteSpecifications(new ResponseListener<JSONObject>() {
     @Override
-    public void onSuccess(Boolean deleted) {
+    public void onSuccess(JSONObject result) {
 
     }
 
@@ -54,7 +54,7 @@ $dataCollection = $kuzzle->collection('collection', 'index');
 
 // Deleting one document
 try {
-  $deleted = $dataCollection->deleteSpecifications();
+  $result = $dataCollection->deleteSpecifications();
 }
 catch (ErrorException $e) {
 
@@ -64,7 +64,9 @@ catch (ErrorException $e) {
 > Callback response:
 
 ```json
-true
+{
+  "acknowledged": true
+}
 ```
 
 Delete specifications linked to the collection object.
@@ -92,9 +94,3 @@ Delete specifications linked to the collection object.
 ## Return value
 
 Returns the `Collection` object to allow chaining.
-
----
-
-## Callback response
-
-Resolves to a boolean confirming the success of the delete action.

--- a/src/sdk-reference/collection/delete-specifications.md
+++ b/src/sdk-reference/collection/delete-specifications.md
@@ -31,7 +31,7 @@ kuzzle
 // Deleting one document
 kuzzle
   .collection("collection", "index")
-  .deleteSpecifications("document unique ID", new ResponseListener<JSONObject>() {
+  .deleteSpecifications(new ResponseListener<JSONObject>() {
     @Override
     public void onSuccess(JSONObject res) {
 

--- a/src/sdk-reference/collection/delete-specifications.md
+++ b/src/sdk-reference/collection/delete-specifications.md
@@ -14,7 +14,7 @@ title: deleteSpecifications
 // Deleting specifications using callbacks (NodeJS or Web Browser)
 kuzzle
   .collection('collection', 'index')
-  .deleteSpecifications(function (err, res) {
+  .deleteSpecifications(function (err, deleted) {
     // callback called once the delete action has been completed
   });
 
@@ -22,7 +22,7 @@ kuzzle
 kuzzle
   .collection('collection', 'index')
   .deleteSpecificationsPromise()
-  .then(res => {
+  .then(deleted => {
     // promises resolved once the delete action has been completed
   });
 ```
@@ -31,9 +31,9 @@ kuzzle
 // Deleting one document
 kuzzle
   .collection("collection", "index")
-  .deleteSpecifications(new ResponseListener<JSONObject>() {
+  .deleteSpecifications(new ResponseListener<Boolean>() {
     @Override
-    public void onSuccess(JSONObject res) {
+    public void onSuccess(Boolean deleted) {
 
     }
 
@@ -54,7 +54,7 @@ $dataCollection = $kuzzle->collection('collection', 'index');
 
 // Deleting one document
 try {
-  $res = $dataCollection->deleteSpecifications();
+  $deleted = $dataCollection->deleteSpecifications();
 }
 catch (ErrorException $e) {
 
@@ -64,7 +64,7 @@ catch (ErrorException $e) {
 > Callback response:
 
 ```json
-[]
+true
 ```
 
 Delete specifications linked to the collection object.
@@ -97,4 +97,4 @@ Returns the `Collection` object to allow chaining.
 
 ## Callback response
 
-Resolves to an empty `array`.
+Resolves to a boolean confirming the success of the delete action.

--- a/src/sdk-reference/collection/delete-specifications.md
+++ b/src/sdk-reference/collection/delete-specifications.md
@@ -1,0 +1,100 @@
+---
+layout: side-code.html
+language-tab:
+  js: Javascript
+  java: Android
+  php: PHP
+algolia: true
+title: deleteSpecifications
+---
+
+# deleteSpecifications
+
+```js
+// Deleting specifications using callbacks (NodeJS or Web Browser)
+kuzzle
+  .collection('collection', 'index')
+  .deleteSpecifications(function (err, res) {
+    // callback called once the delete action has been completed
+  });
+
+// Deleting specifications using promises (NodeJS)
+kuzzle
+  .collection('collection', 'index')
+  .deleteSpecificationsPromise()
+  .then(res => {
+    // promises resolved once the delete action has been completed
+  });
+```
+
+```java
+// Deleting one document
+kuzzle
+  .collection("collection", "index")
+  .deleteSpecifications("document unique ID", new ResponseListener<JSONObject>() {
+    @Override
+    public void onSuccess(JSONObject res) {
+
+    }
+
+    @Override
+    public void onError(JSONObject error) {
+      // Handle error
+    }
+  });
+```
+
+```php
+<?php
+
+use \Kuzzle\Kuzzle;
+
+$kuzzle = new Kuzzle('localhost');
+$dataCollection = $kuzzle->collection('collection', 'index');
+
+// Deleting one document
+try {
+  $res = $dataCollection->deleteSpecifications();
+}
+catch (ErrorException $e) {
+
+}
+```
+
+> Callback response:
+
+```json
+[]
+```
+
+Delete specifications linked to the collection object.
+
+---
+
+## deleteSpecifications([options], [callback])
+
+| Arguments | Type | Description |
+|---------------|---------|----------------------------------------|
+| ``options`` | JSON object | Optional parameters |
+| ``callback`` | function | Optional callback |
+
+---
+
+## Options
+
+| Option | Type | Description | Default |
+|---------------|---------|----------------------------------------|---------|
+| ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
+| ``refresh`` | string | If set to ``wait_for``, Kuzzle will wait the persistence layer indexation to return (available with Elasticsearch 5.x and above) | ``undefined`` |
+
+---
+
+## Return value
+
+Returns the `Collection` object to allow chaining.
+
+---
+
+## Callback response
+
+Resolves to an empty `array`.

--- a/src/sdk-reference/collection/get-specifications.md
+++ b/src/sdk-reference/collection/get-specifications.md
@@ -1,0 +1,119 @@
+---
+layout: side-code.html
+language-tab:
+  js: Javascript
+  java: Android
+  php: PHP
+algolia: true
+title: getSpecifications
+---
+
+# getSpecifications
+
+```js
+// Using callbacks (NodeJS or Web Browser)
+kuzzle
+  .collection('collection', 'index')
+  .getSpecifications(function (error, res) {
+    res.hits.forEach(function (specification) {
+      console.log(specification);
+    });
+    
+    res.total // Total specifications count
+  });
+
+// Using promises (NodeJS)
+kuzzle
+  .collection('collection', 'index')
+  .getSpecificationsPromise()
+  .then(res => {
+    res.hits.forEach(function (specification) {
+      console.log(specification);
+    });
+    
+    res.total // Total specifications count
+  });
+```
+
+```java
+kuzzle
+  .collection("collection", "index")
+  .getSpecifications(new ResponseListener<JSONObject>() {
+    @Override
+    public void onSuccess(JSONObject res) {
+      for (int i = 0; i < res.getJSONArray("hits").length(); i++) {
+        res.getJSONArray("hits").getJSONObject(i) // Specification
+      }
+
+      res.getString("total"); // Total specifications count
+    }
+
+    @Override
+    public void onError(JSONObject error) {
+      // Handle error
+    }
+  });
+```
+
+```php
+<?php
+
+use \Kuzzle\Kuzzle;
+
+$kuzzle = new Kuzzle('localhost');
+$dataCollection = $kuzzle->collection('collection', 'index');
+
+try {
+  $res = $dataCollection->getSpecifications();
+
+  foreach ($res['hits'] as $specification) {
+    // Specification
+  }
+
+  // Total specifications count
+  $res['total'];
+}
+catch (ErrorException $e) {
+
+}
+```
+
+Retrieves the specifications linked to the collection object.
+
+---
+
+## getSpecifications([options], callback)
+
+| Arguments | Type | Description |
+|---------------|---------|----------------------------------------|
+| ``options`` | JSON Object | Optional parameters |
+| ``callback`` | function | Callback handling the response |
+
+---
+
+## Options
+
+| Option | Type | Description | Default |
+|---------------|---------|----------------------------------------|---------|
+| ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
+
+---
+
+## Callback response
+
+```json
+{
+  "validation": {
+    "strict": "true",
+      "fields": {
+        "foo": {
+          "mandatory": "true",
+          "type": "string",
+          "defaultValue": "bar"
+        }
+      }
+    },
+  "index": "index",
+  "collection": "collection"
+}
+```

--- a/src/sdk-reference/collection/get-specifications.md
+++ b/src/sdk-reference/collection/get-specifications.md
@@ -14,24 +14,16 @@ title: getSpecifications
 // Using callbacks (NodeJS or Web Browser)
 kuzzle
   .collection('collection', 'index')
-  .getSpecifications(function (error, res) {
-    res.hits.forEach(function (specification) {
-      console.log(specification);
-    });
-    
-    res.total // Total specifications count
+  .getSpecifications(function (error, specifications) {
+    // specifications is a JSON object
   });
 
 // Using promises (NodeJS)
 kuzzle
   .collection('collection', 'index')
   .getSpecificationsPromise()
-  .then(res => {
-    res.hits.forEach(function (specification) {
-      console.log(specification);
-    });
-    
-    res.total // Total specifications count
+  .then(specifications => {
+    // specifications is a JSON object
   });
 ```
 
@@ -40,12 +32,8 @@ kuzzle
   .collection("collection", "index")
   .getSpecifications(new ResponseListener<JSONObject>() {
     @Override
-    public void onSuccess(JSONObject res) {
-      for (int i = 0; i < res.getJSONArray("hits").length(); i++) {
-        res.getJSONArray("hits").getJSONObject(i) // Specification
-      }
-
-      res.getString("total"); // Total specifications count
+    public void onSuccess(JSONObject specifications) {
+        // specifications is a JSONObject
     }
 
     @Override
@@ -64,17 +52,29 @@ $kuzzle = new Kuzzle('localhost');
 $dataCollection = $kuzzle->collection('collection', 'index');
 
 try {
-  $res = $dataCollection->getSpecifications();
-
-  foreach ($res['hits'] as $specification) {
-    // Specification
-  }
-
-  // Total specifications count
-  $res['total'];
+  $specifications = $dataCollection->getSpecifications();
 }
 catch (ErrorException $e) {
 
+}
+```
+
+> Callback response
+
+```json
+{
+  "validation": {
+    "strict": "true",
+      "fields": {
+        "foo": {
+          "mandatory": "true",
+          "type": "string",
+          "defaultValue": "bar"
+        }
+      }
+    },
+  "index": "index",
+  "collection": "collection"
 }
 ```
 
@@ -96,24 +96,3 @@ Retrieves the specifications linked to the collection object.
 | Option | Type | Description | Default |
 |---------------|---------|----------------------------------------|---------|
 | ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
-
----
-
-## Callback response
-
-```json
-{
-  "validation": {
-    "strict": "true",
-      "fields": {
-        "foo": {
-          "mandatory": "true",
-          "type": "string",
-          "defaultValue": "bar"
-        }
-      }
-    },
-  "index": "index",
-  "collection": "collection"
-}
-```

--- a/src/sdk-reference/collection/scroll-specifications.md
+++ b/src/sdk-reference/collection/scroll-specifications.md
@@ -81,6 +81,18 @@ catch (ErrorException $e) {
 }
 ```
 
+> Callback response
+
+```json
+{
+  "hits": [
+    {"first": "specification"},
+    {"second": "specification"}
+  ],
+  "total": 2
+}
+```
+
 Returns a JSON object containing the next page of the scroll session, and the `scrollId` to be used by the next `scroll` action.  
 A scroll session is always initiated by a `searchSpecification` action by using the `scroll` argument.
 
@@ -102,19 +114,3 @@ A scroll session is always initiated by a `searchSpecification` action by using 
 |---------------|---------|----------------------------------------|---------|
 | ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
 | ``scroll`` | string | Re-initializes the scroll session timeout to its value. If not defined, the scroll timeout is defaulted to a Kuzzle configuration | ``undefined`` |
-
----
-
-## Callback response
-
-```json
-{
-  "hits": [
-    {"first": "specification"},
-    {"second": "specification"}
-  ],
-  "total": 2
-}
-```
-
----

--- a/src/sdk-reference/collection/scroll-specifications.md
+++ b/src/sdk-reference/collection/scroll-specifications.md
@@ -1,0 +1,120 @@
+---
+layout: side-code.html
+language-tab:
+  js: Javascript
+  java: Android
+  php: PHP
+algolia: true
+title: scrollSpecifications
+---
+
+# scrollSpecifications
+
+```js
+// Using callbacks (NodeJS or Web Browser)
+kuzzle
+  .collection('collection', 'index')
+  .scrollSpecifications(scrollId, {scroll: '1m'}, function (err, res) {
+    res.hits.forEach(function (specification) {
+      console.log(specification);      
+    });
+    
+    res.total // Total specifications count
+  });
+
+// Using promises (NodeJS only)
+kuzzle
+  .collection('collection', 'index')
+  .scrollSpecificationsPromise(scrollId, {scroll: '1m'})
+  .then(res => {
+    res.hits.forEach(specification => {
+      console.log(specification);
+    });
+    
+    res.total // Total specifications count
+  });
+```
+
+```java
+Options opts = new Options();
+opts.setScroll("1m");
+
+kuzzle
+  .collection("collection", "index")
+  .scrollSpecifications(scrollId, opts, new ResponseListener<JSONObject>() {
+    @Override
+    public void onSuccess(JSONObject res) {
+      for (int i = 0; i < res.getJSONArray("hits").length(); i++) {
+          res.getJSONArray("hits").getJSONObject(i) // Specification
+      }
+
+      res.getString("total"); // Total specifications count
+    }
+
+    @Override
+    public void onError(JSONObject error) {
+      // Handle error
+    }
+  });
+```
+
+```php
+<?php
+
+use \Kuzzle\Kuzzle;
+
+$kuzzle = new Kuzzle('localhost');
+$dataCollection = $kuzzle->collection('collection', 'index');
+
+try {
+  $res = $dataCollection->scrollSpecifications($scrollId, ['scroll' => '1m']);
+
+  foreach ($res['hits'] as $specification) {
+    // Specification
+  }
+  
+  // Total specifications count
+  $res['total'];
+}
+catch (ErrorException $e) {
+
+}
+```
+
+Returns a JSON object containing the next page of the scroll session, and the `scrollId` to be used by the next `scroll` action.  
+A scroll session is always initiated by a `searchSpecification` action by using the `scroll` argument.
+
+---
+
+## scrollSpecifications(scrollId, [options], callback)
+
+| Arguments | Type | Description |
+|---------------|---------|----------------------------------------|
+| ``scrollId`` | string | The "scrollId" provided with the last scrollSpecifications response or from the initial searchSpecifications request |
+| ``options`` | JSON object | Optional parameters |
+| ``callback`` | function | Callback handling the response |
+
+---
+
+## Options
+
+| Option | Type | Description | Default |
+|---------------|---------|----------------------------------------|---------|
+| ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
+| ``scroll`` | string | Re-initializes the scroll session timeout to its value. If not defined, the scroll timeout is defaulted to a Kuzzle configuration | ``undefined`` |
+
+---
+
+## Callback response
+
+```json
+{
+  "hits": [
+    {"first": "specification"},
+    {"second": "specification"}
+  ],
+  "total": 2
+}
+```
+
+---

--- a/src/sdk-reference/collection/search-specifications.md
+++ b/src/sdk-reference/collection/search-specifications.md
@@ -114,6 +114,19 @@ catch (ErrorException $e) {
 }
 ```
 
+> Callback response
+
+```json
+{
+  "hits": [
+    {"first": "specification"},
+    {"second": "specification"}
+  ],
+  "total": 2,
+  "scrollId": "foobar"
+}
+```
+
 Retrieves every specifications across indexes/collections according to the given filters.
 
 ---
@@ -136,18 +149,3 @@ Retrieves every specifications across indexes/collections according to the given
 | ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
 | ``scroll`` | string | Start a scroll session, with a time to live equals to this parameter's value following the [Elastisearch time format](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/common-options.html#time-units) | ``undefined`` |
 | ``size`` | number | Provide the maximum number of results of the request (used to paginate results) | ``10`` |
-
----
-
-## Callback response
-
-```json
-{
-  "hits": [
-    {"first": "specification"},
-    {"second": "specification"}
-  ],
-  "total": 2,
-  "scrollId": "foobar"
-}
-```

--- a/src/sdk-reference/collection/search-specifications.md
+++ b/src/sdk-reference/collection/search-specifications.md
@@ -1,0 +1,153 @@
+---
+layout: side-code.html
+language-tab:
+  js: Javascript
+  java: Android
+  php: PHP
+algolia: true
+title: searchSpecifications
+---
+
+# searchSpecifications
+
+```js
+const
+  filters = {
+    match_all: {
+      boost: 1
+    }
+  },
+  options= {
+    from: 0,
+    size: 20
+  };
+
+// Using callbacks (NodeJS or Web Browser)
+kuzzle
+  .collection('collection', 'index')
+  .searchSpecifications(filters, options, function (err, res) {
+    res.hits.forEach(function (specification) {
+      console.log(specification);
+    });
+    
+    res.total // Total specifications count
+  });
+
+// Using promises (NodeJS only)
+kuzzle
+  .collection('collection', 'index')
+  .searchSpecificationsPromise(filters, options)
+  .then(res => {
+    res.hits.forEach(specification => {
+      console.log(specification);
+    });
+    
+    res.total // Total specifications count
+  });
+```
+
+```java
+import io.kuzzle.sdk.core.Kuzzle;
+import io.kuzzle.sdk.core.Options; 
+
+Kuzzle kuzzle = new Kuzzle("localhost");
+
+JSONObject filters = new JSONObject()
+   .put("match_all", new JSONObject()
+       .put("boost", 1)
+   );
+
+Options options = new Options();
+options.setFrom((long) 0);
+options.setSize((long) 20);
+
+kuzzle
+  .collection("collection", "index")
+  .searchSpecifications(filters, options, new ResponseListener<JSONObject>() {
+    @Override
+    public void onSuccess(JSONObject res) {
+      for (int i = 0; i < res.getJSONArray("hits").length(); i++) {
+        res.getJSONArray("hits").getJSONObject(i) // Specification
+      }
+
+      res.getString("total"); // Total specifications count
+    }
+
+    @Override
+    public void onError(JSONObject error) {
+      // Handle error
+    }
+  });
+```
+
+```php
+<?php
+
+use \Kuzzle\Kuzzle;
+
+$filters = [
+    "match_all" => [
+        "boost" => 1
+    ]
+];
+
+$options = [
+  'from' => 0,
+  'size' => 20
+];
+
+$kuzzle = new Kuzzle('localhost');
+$dataCollection = $kuzzle->collection('collection', 'index');
+
+try {
+  $res = $dataCollection->searchSpecifications($filters, $options);
+  
+  foreach ($res['hits'] as $specification) {
+    // Specification
+  }
+  
+  // Total specifications count
+  $res['total'];
+}
+catch (ErrorException $e) {
+
+}
+```
+
+Retrieves every specifications across indexes/collections according to the given filters.
+
+---
+
+## searchSpecifications(filters, [options], callback)
+
+| Arguments | Type | Description |
+|---------------|---------|----------------------------------------|
+| ``filters`` | JSON object | Search request body, using [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-request-body.html) format. <br>If given an empty object, matches all specifications across index/collections |
+| ``options`` | JSON object | Optional parameters |
+| ``callback`` | function | Callback handling the response |
+
+---
+
+## Options
+
+| Option | Type | Description | Default |
+|---------------|---------|----------------------------------------|---------|
+| ``from`` | number | Provide the starting offset of the request (used to paginate results) | ``0`` |
+| ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
+| ``scroll`` | string | Start a scroll session, with a time to live equals to this parameter's value following the [Elastisearch time format](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/common-options.html#time-units) | ``undefined`` |
+| ``size`` | number | Provide the maximum number of results of the request (used to paginate results) | ``10`` |
+
+---
+
+## Callback response
+
+```json
+{
+  "hits": [
+    {"first": "specification"},
+    {"second": "specification"}
+  ],
+  "total": 2,
+  "scrollId": "foobar"
+}
+```

--- a/src/sdk-reference/collection/search.md
+++ b/src/sdk-reference/collection/search.md
@@ -218,7 +218,7 @@ $kuzzle = new Kuzzle('localhost');
 $dataCollection = $kuzzle->collection('collection', 'index');
 
 try {
-  $searchResult = $dataCollection->search($body, options);
+  $searchResult = $dataCollection->search($body, $options);
 
   // $searchResult instanceof SearchResult
   $searchResult->getTotal();

--- a/src/sdk-reference/collection/update-specifications.md
+++ b/src/sdk-reference/collection/update-specifications.md
@@ -1,0 +1,118 @@
+---
+layout: side-code.html
+language-tab:
+  js: Javascript
+  java: Android
+  php: PHP
+algolia: true
+title: updateSpecifications
+---
+
+# updateSpecifications
+
+```js
+// Using callbacks (NodeJS or Web Browser)
+kuzzle
+  .collection('collection', 'index')
+  .updateSpecifications({specification: 'content'}, function (err, res) {
+    // result is a JSON object
+  });
+
+// Using promises (NodeJS)
+kuzzle
+  .collection('collection', 'index')
+  .updateSpecificationsPromise({specification: 'content'})
+  .then(res => {
+    // result is a JSON object
+  });
+```
+
+```java
+JSONObject specificationContent = new JSONObject().put("specification", "content");
+
+kuzzle
+  .collection("collection", "index")
+  .updateSpecifications(specificationContent, new ResponseListener<JSONObject>() {
+    @Override
+    public void onSuccess(JSONObject res) {
+      // result is a JSONObject
+    }
+
+    @Override
+    public void onError(JSONObject error) {
+      // Handle error
+    }
+  });
+```
+
+```php
+<?php
+
+use \Kuzzle\Kuzzle;
+
+$documentId = 'foobar';
+$specificationContent = [
+  'specification' => 'content'
+];
+
+$kuzzle = new Kuzzle('localhost');
+$dataCollection = $kuzzle->collection('collection', 'index');
+
+try {
+  // result is an array
+  $res = $dataCollection->updateSpecifications($specificationContent);
+}
+catch (ErrorException $e) {
+
+}
+```
+
+Update parts of a specification, by replacing some fields or adding new ones.  
+Note that you cannot remove fields this way: missing fields will simply be left unchanged.
+
+---
+
+## updateSpecifications(content, [options], [callback])
+
+| Arguments | Type | Description |
+|---------------|---------|----------------------------------------|
+| ``content`` | JSON object | Content of the specification to update |
+| ``options`` | JSON object | Optional parameters |
+| ``callback`` | function | Optional callback |
+
+---
+
+## Options
+
+| Option | Type | Description | Default |
+|---------------|---------|----------------------------------------|---------|
+| ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
+| ``refresh`` | string | If set to ``wait_for``, Kuzzle will wait the persistence layer indexation to return (available with Elasticsearch 5.x and above) | ``undefined`` |
+| ``retryOnConflict`` | int | Number of retries to attempt before rejecting this update because of a cluster sync conflict | `0` |
+
+---
+
+## Return value
+
+Returns the `Collection` object to allow chaining.
+
+---
+
+## Callback response
+
+```json
+{
+  "index": {
+    "collection": {
+      "strict":"true",
+      "fields": {
+        "foo": {
+          "mandatory": "true",
+          "type": "string",
+          "defaultValue": "bar"
+        }
+      }
+    }
+  }
+}
+```

--- a/src/sdk-reference/collection/update-specifications.md
+++ b/src/sdk-reference/collection/update-specifications.md
@@ -11,28 +11,49 @@ title: updateSpecifications
 # updateSpecifications
 
 ```js
+var specifications = {
+  strict: 'true',
+  fields: {
+    foo: {
+      mandatory: true,
+      type: 'string',
+      defaultValue: 'bar'
+    }
+  }
+};
+
 // Using callbacks (NodeJS or Web Browser)
 kuzzle
   .collection('collection', 'index')
-  .updateSpecifications({specification: 'content'}, function (err, res) {
+  .updateSpecifications(specifications, function (err, res) {
     // result is a JSON object
   });
 
 // Using promises (NodeJS)
 kuzzle
   .collection('collection', 'index')
-  .updateSpecificationsPromise({specification: 'content'})
+  .updateSpecificationsPromise(specifications)
   .then(res => {
     // result is a JSON object
   });
 ```
 
 ```java
-JSONObject specificationContent = new JSONObject().put("specification", "content");
+JSONObject fooField = new JSONObject()
+    .put("mandatory", "true")
+    .put("type", "string")
+    .put("defaultValue", "bar");
+
+JSONObject fields = new JSONObject()
+    .put("foo", fooField);
+
+JSONObject specifications = new JSONObject()
+    .put("strict", "true")
+    .put("fields", fields);
 
 kuzzle
   .collection("collection", "index")
-  .updateSpecifications(specificationContent, new ResponseListener<JSONObject>() {
+  .updateSpecifications(specifications, new ResponseListener<JSONObject>() {
     @Override
     public void onSuccess(JSONObject res) {
       // result is a JSONObject
@@ -50,9 +71,15 @@ kuzzle
 
 use \Kuzzle\Kuzzle;
 
-$documentId = 'foobar';
-$specificationContent = [
-  'specification' => 'content'
+$specifications = [
+    'strict' => true,
+    'fields' => [
+        'foo' => [
+            'mandatory' => true,
+            'type' => 'string',
+            'defaultValue' => 'bar'
+        ]
+    ]
 ];
 
 $kuzzle = new Kuzzle('localhost');
@@ -60,10 +87,29 @@ $dataCollection = $kuzzle->collection('collection', 'index');
 
 try {
   // result is an array
-  $res = $dataCollection->updateSpecifications($specificationContent);
+  $res = $dataCollection->updateSpecifications($specifications);
 }
 catch (ErrorException $e) {
 
+}
+```
+
+> Callback response
+
+```json
+{
+  "index": {
+    "collection": {
+      "strict":"true",
+      "fields": {
+        "foo": {
+          "mandatory": "true",
+          "type": "string",
+          "defaultValue": "bar"
+        }
+      }
+    }
+  }
 }
 ```
 
@@ -95,24 +141,3 @@ Note that you cannot remove fields this way: missing fields will simply be left 
 ## Return value
 
 Returns the `Collection` object to allow chaining.
-
----
-
-## Callback response
-
-```json
-{
-  "index": {
-    "collection": {
-      "strict":"true",
-      "fields": {
-        "foo": {
-          "mandatory": "true",
-          "type": "string",
-          "defaultValue": "bar"
-        }
-      }
-    }
-  }
-}
-```

--- a/src/sdk-reference/collection/validate-specifications.md
+++ b/src/sdk-reference/collection/validate-specifications.md
@@ -11,28 +11,49 @@ title: validateSpecifications
 # validateSpecifications
 
 ```js
+var specifications = {
+  strict: 'true',
+  fields: {
+    foo: {
+      mandatory: true,
+      type: 'string',
+      defaultValue: 'bar'
+    }
+  }
+};
+
 // Using callbacks (NodeJS or Web Browser)
 kuzzle
   .collection('collection', 'index')
-  .validateSpecifications({specification: 'content'}, function (err, isValid) {
+  .validateSpecifications(specifications, function (err, isValid) {
     // isValid is a boolean
   });
 
 // Using promises (NodeJS)
 kuzzle
   .collection('collection', 'index')
-  .validateSpecificationsPromise({specification: 'content'})
+  .validateSpecificationsPromise(specifications)
   .then(isValid => {
     // isValid is a boolean
   });
 ```
 
 ```java
-JSONObject specificationContent = new JSONObject().put("specification", "content");
+JSONObject fooField = new JSONObject()
+    .put("mandatory", "true")
+    .put("type", "string")
+    .put("defaultValue", "bar");
+
+JSONObject fields = new JSONObject()
+    .put("foo", fooField);
+
+JSONObject specifications = new JSONObject()
+    .put("strict", "true")
+    .put("fields", fields);
 
 kuzzle
   .collection("collection", "index")
-  .validateSpecifications(specificationContent, new ResponseListener<Boolean>() {
+  .validateSpecifications(specifications, new ResponseListener<Boolean>() {
     @Override
     public void onSuccess(Boolean isValid) {
       // isValid is a boolean
@@ -50,9 +71,15 @@ kuzzle
 
 use \Kuzzle\Kuzzle;
 
-$documentId = 'foobar';
-$specificationContent = [
-  'specification' => 'content'
+$specifications = [
+    'strict' => true,
+    'fields' => [
+        'foo' => [
+            'mandatory' => true,
+            'type' => 'string',
+            'defaultValue' => 'bar'
+        ]
+    ]
 ];
 
 $kuzzle = new Kuzzle('localhost');
@@ -60,7 +87,7 @@ $dataCollection = $kuzzle->collection('collection', 'index');
 
 try {
   // $isValid is a boolean
-  $isValid = $dataCollection->validateSpecifications($specificationContent);
+  $isValid = $dataCollection->validateSpecifications($specifications);
 }
 catch (ErrorException $e) {
 

--- a/src/sdk-reference/collection/validate-specifications.md
+++ b/src/sdk-reference/collection/validate-specifications.md
@@ -1,0 +1,94 @@
+---
+layout: side-code.html
+language-tab:
+  js: Javascript
+  java: Android
+  php: PHP
+algolia: true
+title: validateSpecifications
+---
+
+# validateSpecifications
+
+```js
+// Using callbacks (NodeJS or Web Browser)
+kuzzle
+  .collection('collection', 'index')
+  .validateSpecifications({specification: 'content'}, function (err, isValid) {
+    // isValid is a boolean
+  });
+
+// Using promises (NodeJS)
+kuzzle
+  .collection('collection', 'index')
+  .validateSpecificationsPromise({specification: 'content'})
+  .then(isValid => {
+    // isValid is a boolean
+  });
+```
+
+```java
+JSONObject specificationContent = new JSONObject().put("specification", "content");
+
+kuzzle
+  .collection("collection", "index")
+  .validateSpecifications(specificationContent, new ResponseListener<Boolean>() {
+    @Override
+    public void onSuccess(Boolean isValid) {
+      // isValid is a boolean
+    }
+
+    @Override
+    public void onError(JSONObject error) {
+      // Handle error
+    }
+  });
+```
+
+```php
+<?php
+
+use \Kuzzle\Kuzzle;
+
+$documentId = 'foobar';
+$specificationContent = [
+  'specification' => 'content'
+];
+
+$kuzzle = new Kuzzle('localhost');
+$dataCollection = $kuzzle->collection('collection', 'index');
+
+try {
+  // $isValid is a boolean
+  $isValid = $dataCollection->validateSpecifications($specificationContent);
+}
+catch (ErrorException $e) {
+
+}
+```
+
+Validate a specification, returning whether or not the provided specification as a valid format or not.
+
+---
+
+## validateSpecifications(content, [options], callback)
+
+| Arguments | Type | Description |
+|---------------|---------|----------------------------------------|
+| ``content`` | JSON object | Content of the specification to validate |
+| ``options`` | JSON object | Optional parameters |
+| ``callback`` | function | Callback handling the response |
+
+---
+
+## Options
+
+| Option | Type | Description | Default |
+|---------------|---------|----------------------------------------|---------|
+| ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
+
+---
+
+## Callback response
+
+Resolves to a boolean indicating whether or not the provided specifications are valid or not.


### PR DESCRIPTION
# Introduces
- Documentation for specifications CRUDL routes (get - search - scroll - update - delete - validate)

Document following Pull Requests:
https://github.com/kuzzleio/sdk-javascript/pull/231
https://github.com/kuzzleio/sdk-php/pull/77
https://github.com/kuzzleio/sdk-android/pull/135