### PR TITLE
Remove obsolete "proxy:" events

### DIFF
--- a/src/plugins-reference/kuzzle-events-list/index.md
+++ b/src/plugins-reference/kuzzle-events-list/index.md
@@ -172,17 +172,6 @@ Events triggered during Kuzzle startup, when the database is prepared for Kuzzle
 
 ---
 
-## proxy
-
-Events triggered when interacting with `proxy`.
-
-| Event | Description | Payload |
-|-------|-------------|---------|
-| `proxy:joinChannel`  | Triggered after attaching a user to a room. You can't modify the input on this event      | Type: Object.<br> `{channel, id}`<br> `channel` is the channel name.<br> `id` is the connection id                                                                             |
-| `proxy:leaveChannel` | Triggered before a room is removed for the user. You can't modify the input on this event | Type: Object.<br> `{channel, id}`<br> `channel` is the channel name.<br> `id` is the connection id                                                                             |
-
----
-
 ## realtime
 
 Events triggered when a request is sent to the [`realtime` controller]({{ site_base_path }}api-documentation/controller-realtime).

--- a/src/plugins-reference/kuzzle-events-list/index.md
+++ b/src/plugins-reference/kuzzle-events-list/index.md
@@ -178,10 +178,8 @@ Events triggered when interacting with `proxy`.
 
 | Event | Description | Payload |
 |-------|-------------|---------|
-| `proxy:broadcast`    | Triggered before broadcast. You can't modify the input on this event                      | Type: Object.<br> `{payload, channelsList}`<br> `payload` is the notification content. <br>`channelsList` is an array of channels to broadcast.                                |
 | `proxy:joinChannel`  | Triggered after attaching a user to a room. You can't modify the input on this event      | Type: Object.<br> `{channel, id}`<br> `channel` is the channel name.<br> `id` is the connection id                                                                             |
 | `proxy:leaveChannel` | Triggered before a room is removed for the user. You can't modify the input on this event | Type: Object.<br> `{channel, id}`<br> `channel` is the channel name.<br> `id` is the connection id                                                                             |
-| `proxy:notify`       | Triggered before notifying a connection id                                                | Type: Object.<br> `{payload, channelsList, id}`<br> `payload` is the notification content. <br>`channelsList` is an array of channels to notify.<br> `id` is the connection id |
 
 ---
 


### PR DESCRIPTION
# Description

Following https://github.com/kuzzleio/kuzzle/issues/790#issuecomment-308458272 , obsolete and unusable events are removed from Kuzzle
