### PR TITLE
Add explanations to the API notifications documentation

### DIFF
--- a/src/kuzzle-dsl/roomid/index.md
+++ b/src/kuzzle-dsl/roomid/index.md
@@ -1,0 +1,44 @@
+---
+layout: full.html
+algolia: true
+title: Room Identifiers
+description: How room identifiers are generated
+order: 0
+---
+
+# Room identifiers
+
+Kuzzle Room identifiers are calculated from the filters provided to the DSL, guaranteeing that differently written filters matching the same scope will get the same identifier.
+
+For instance, both these filters will get the same room identifier:
+
+```json
+{
+  "and": [
+    {
+      "not": {
+        "in": {"some_document_field": ["foo", "bar"]}
+      }
+    },
+    {"missing": {"field": "another_field"}}
+  ]
+}
+```
+
+And:
+
+```json
+{
+  "not": {
+    "or": [
+      {
+        "or": [
+          {"equals": {"some_document_field": "foo"}},
+          {"equals": {"some_document_field": "bar"}}
+        ]
+      },
+      {"exists": {"field": "another_field"}}
+    ]
+  }
+}
+```

--- a/src/kuzzle-dsl/terms/index.md
+++ b/src/kuzzle-dsl/terms/index.md
@@ -3,5 +3,5 @@ layout: category-members.html
 algolia: true
 title: Filter terms
 description: filter your queries with terms
-order: 0
+order: 100
 ---


### PR DESCRIPTION
# Description

Add more details, examples and advanced options explanations on the API notification documentation page.

# Other changes

Add explanations about how DSL room identifiers are calculated by Kuzzle. This allows adding links from the new API notifications section to this new page, making explanations clearer

# Solved issue

#54 
