### PR TITLE
New notification format and related events

### DIFF
--- a/src/api-documentation/controller-realtime/subscribe.md
+++ b/src/api-documentation/controller-realtime/subscribe.md
@@ -131,7 +131,7 @@ title: subscribe
       /*
       {
         "status": 200,
-        "error": null,
+        "type": "document",
         "index": "index",
         "collection":"collection",
         "controller": "realtime",
@@ -140,9 +140,7 @@ title: subscribe
         "scope": "in",
         "requestId": "<unique request identifier>",
         "result":{
-          "roomId":"632682a9eac95cfb95e3a697b29b7739",
-          "requestId":"mySubscription",
-          "timestamp":1449564937142
+          "some real-time": "message"
         }
       }
       */
@@ -185,8 +183,8 @@ title: subscribe
 
       /*
       {
-        "error": null,
         "status": 200,
+        "type": "document",
         "index": "<index>",
         "collection": "<collection>"
         "controller": "realtime",
@@ -194,9 +192,7 @@ title: subscribe
         "state": "done",
         "volatile": {},
         "result": {
-          "roomId": "632682a9eac95cfb95e3a697b29b7739",
-          "requestId": "mySubscription",
-          "timestamp": 1449564937142
+          "some real-time": "message"
         }
       }
       */
@@ -226,8 +222,8 @@ and you'll effectively listen to a "topic".
 
 Once you have subscribed to a room, depending on your filters, you may receive the following notifications:
 
-* whenever a pub/sub message is published matching your criteria (realtime)
-* whenever a matching document is about to be created or deleted (realtime)
+* whenever a pub/sub message is published matching your criteria (real-time)
+* whenever a matching document is about to be created or deleted (real-time)
 * whenever a matching stored document is created, updated or deleted (once the change is effective in the database)
 * whenever a user enters or leaves the room
 

--- a/src/api-documentation/kuzzle-response/index.md
+++ b/src/api-documentation/kuzzle-response/index.md
@@ -32,13 +32,6 @@ _NB: For more details about status code and error object, see status-codes.md_
   "controller": "<controller>",
   "action": "<action>",
 
-  // For notification only, completion state of the request.
-  // A pending request will receive a "done" notification once it is processed by Kuzzle.
-  "state": "<done|pending>",
-
-  // For notifications only, indicates if the document is added or removed from the subscription.
-  "scope": "<in|out>",
-
   // Arbitrary data repeated from the initial request (optional).
   "volatile": { foo: "bar" },
 

--- a/src/api-documentation/volatile-data/index.md
+++ b/src/api-documentation/volatile-data/index.md
@@ -11,10 +11,9 @@ subheader-title: Introduction
 # Sending volatile data
 
 In every request you send to Kuzzle, you can include a `volatile` object.
-This object content will be ignored by Kuzzle,
-but it will also be forwarded back in `responses` and in `notifications` (see below).
+This object content will be ignored by Kuzzle, but it will also be forwarded back in [responses]({{ site_base_path }}api-documentation/kuzzle-response/) and in [notifications]({{ site_base_path }}api-documentation/notifications/).
 
-You can also include volatile information to a subscription request.
+You can also provide volatile information to a subscription request.
 These volatile information will be forwarded to other subscribers at the moment of the subscription,
 and when you leave the room. Please note that when leaving the room,
-the forwarded volatile data are those provided in the **subscription** request.
+the forwarded volatile data are those provided to the **subscription** request.

--- a/src/api-documentation/volatile-data/subscribe-to-room.md
+++ b/src/api-documentation/volatile-data/subscribe-to-room.md
@@ -29,19 +29,17 @@ order: 200
 ```javascript
 {
   "status": 200,
-  "error": null,
+  "type": "user",
   "index": "<index>",
   "collection": "<collection>",
   "controller": "realtime",
   "action": "unsubscribe",
   "state": "done",
-  "scope": "out", // notice scope out, which mean that something are leaving our subscription
+  "user": "out", // Tells you that a user left the room
   "volatile": { // volatile data will only be received by subscribers
     "hello": "my name is Bob"
   },
-  "requestId": "<unique request identifier>",
   "result": {
-    "roomId": "<unique Kuzzle room identifier>",
     "count": "<the new user count on that room>"
   }
 }

--- a/src/api-documentation/volatile-data/updating-document.md
+++ b/src/api-documentation/volatile-data/updating-document.md
@@ -31,13 +31,12 @@ order: 100
 ```javascript
 {
   "status": 200,
-  "error": null,
   "index": "<index>",
   "collection": "<collection>",
   "controller": "document",
   "action": "update",
   "state": "pending",
-  "scope": "<in|out>",
+  "scope": "unknown",
   "volatile": { // volatile data will only be received by subscribers
     "modifiedBy": "awesome me",
     "reason": "it needed to be modified"
@@ -48,7 +47,7 @@ order: 100
     "_source": {
       "somefield": "now has a new value",
       "someOtherField": "was left unchanged"
-    },
+    }
   }
 }
 ```

--- a/src/guide/essentials/installing-backoffice.md
+++ b/src/guide/essentials/installing-backoffice.md
@@ -7,7 +7,7 @@ order: 100
 
 # Installing Kuzzle Backoffice
 
-The Kuzzle Backoffice is a handy **web application** that helps you administrate Kuzzle. You can use it to **manage your data**, subscribe to **realtime notifications** and manage **security** rules.
+The Kuzzle Backoffice is a handy **web application** that helps you administrate Kuzzle. You can use it to **manage your data**, subscribe to **real-time notifications** and manage **security** rules.
 
 You can use the <a href="http://kuzzle-backoffice.netlify.com/">publicly hosted Kuzzle Backoffice</a>.
 If you want to host the Kuzzle Backoffice on your own server, you can download the source code [here](https://github.com/kuzzleio/kuzzle-backoffice/releases).

--- a/src/guide/essentials/persisted.md
+++ b/src/guide/essentials/persisted.md
@@ -433,4 +433,4 @@ The syntax to use is the one defined by [Elasticsearch](https://www.elastic.co/g
 
 
 * Refer to the [Elasticsearch cookbook]({{ site_base_path }}elasticsearch-cookbook) to get more details on how querying works in Kuzzle.
-* Keep track of the changes on your documents via the [Realtime Notifications]({{ site_base_path }}guide/essentials/real-time).
+* Keep track of the changes on your documents via the [Real-time Notifications]({{ site_base_path }}guide/essentials/real-time).

--- a/src/guide/kuzzle-depth/request-life-cycle.md
+++ b/src/guide/kuzzle-depth/request-life-cycle.md
@@ -223,14 +223,14 @@ The following diagram shows how two different clients, a Websocket and a MQ one,
 
 ![pubsub_scenario_details1]({{ site_base_path }}assets/images/request-scenarios/pubsub/details1.png)
 
-* The client application opens a Websocket or a MQ connection and emits a "subscribe" event with some filters (see the [API Documentation]({{ site_base_path }}api-documentation/controller-realtime/subscribe)). For instance, to be notified about all contents posted to the collection `users`, containing a field `hobby` equals to `computer`:
+* The client application opens a Websocket or a MQ connection and emits a "subscribe" event with some filters (see the [API Documentation]({{ site_base_path }}api-documentation/controller-realtime/subscribe)). For instance, to be notified about any content posted to the collection `users`, containing a field `hobby` equals to `computer`:
 
 ```javascript
 {
-  "requestId": "ed4faaff-253a-464f-a6b3-387af9d8483d",
   "index": "mainindex",
   "collection": "users",
-  "action": "on",
+  "controller": "realtime",
+  "action": "subscribe",
   "body": {
     "equals": {
       "hobby": "computer"
@@ -282,9 +282,8 @@ Sample response content:
   "error": null,
   "index": "mainindex",
   "collection": "users",
-  "controller": "subscribe",
-  "action": "on",
-  "state": "all",
+  "controller": "realtime",
+  "action": "subscribe",
   "requestId": "ed4faaff-253a-464f-a6b3-387af9d8483d",
   "result": {
     "roomId": "78c5b0ba-fead-4535-945c-8d64a7927459",

--- a/src/kuzzle-events/notify/index.md
+++ b/src/kuzzle-events/notify/index.md
@@ -1,0 +1,20 @@
+---
+layout: full.html
+algolia: true
+title: notify
+description: real-time notifications events
+order: 200
+---
+
+# notify
+
+These events are triggered by Kuzzle's real-time engine, every time [a notification]({{ site_base_path }}api-documentation/notifications/) is about to be sent to subscribing clients.
+
+[Synchronously listening plugin]({{ site_base_path }}plugins-reference/plugins-features/adding-pipes/) may block some (or all) notifications by rejecting the provided promise.
+
+| Event | Type | Description | Payload |
+|-------|------|-------------|---------|
+| `notify:dispatch` | Pipe | A [Notification]({{ site_base_path }}api-documentation/notifications/) is about to be sent. Can be a document, a user or a server notification. <br/>Use the `type` property to determine the notification type. | An object representing the notification to send |
+| `notify:document` | Pipe | A [Document Notification]({{ site_base_path }}api-documentation/notifications/#document-notifications) is about to be sent | An object representing the notification to send  |
+| `notify:server` | Pipe | A [Server Notification]({{ site_base_path }}api-documentation/notifications/#server-notifications) is about to be sent | An object representing the notification to send |
+| `notify:user` | Pipe | A [User Notificaiton]({{ site_base_path }}api-documentation/notifications/#subscription-notifications) is about to be sent | An object representing the notification to send |

--- a/src/sdk-reference/essentials/events.md
+++ b/src/sdk-reference/essentials/events.md
@@ -17,13 +17,13 @@ The [Kuzzle object]({{ site_base_path }}sdk-reference/kuzzle/) exposes a set of 
 | ``connected`` | _(none)_ | Triggered when the SDK has successfully connected to Kuzzle |
 | `discarded` | `error` (object) | Triggered when Kuzzle rejects a request (e.g. request can't be parsed, request too large, ...) |
 | ``disconnected`` | _(none)_ |  Triggered when the current session has been unexpectedly disconnected |
-| ``jwtTokenExpired`` | _(none)_ |  Triggered when Kuzzle rejected a request because the authentication token expired |
 | ``loginAttempt`` | `{ "success": <boolean>, "error": "<error message>" }` |  Triggered when a login attempt completes, either with a success or a failure result |
 | ``networkError`` | `error` (object) | Triggered when the SDK has failed to connect to Kuzzle. Does not trigger offline mode. |
 | ``offlineQueuePop`` | `query` (object) | Triggered whenever a request is removed from the offline queue. |
 | ``offlineQueuePush`` | `{ "query": <object>, "cb": <function> }` | Triggered whenever a request is added to the offline queue |
 | ``queryError`` | `error` (object), `query` (object) | Triggered whenever Kuzzle responds with an error |
 | ``reconnected`` | _(none)_ |  Triggered when the current session has reconnected to Kuzzle after a disconnection, and only if ``autoReconnect`` is set to ``true`` |
+| ``tokenExpired`` | _(none)_ |  Triggered when Kuzzle rejected a request because the authentication token expired |
 
 
 **Note:** listeners are called in the order of their insertion.

--- a/src/sdk-reference/essentials/notifications.md
+++ b/src/sdk-reference/essentials/notifications.md
@@ -16,9 +16,9 @@ To subscribe, you must provide a callback that will be called each time a new no
 Once you have subscribed, depending on the subscription configuration you provided, you may receive the following push notifications:
 
 * a pub/sub message matches your criteria (real-time)
-* a matching document is about to be created or deleted (real-time)
+* a matching document is about to be created or deleted in real-time (deactivated by default)
 * a matching document is created, updated or deleted (once the change is effective in the database)
-* a user enters or leaves the room
+* a user enters or leaves the room (deactivated by default)
 
 You may subscribe multiple times to the same room, with identical or different subscription parameters, and with different callbacks. This allows dispatching notifications across the right parts of your application, instead of having to maintain an all-purpose notification consumer (but you can do that, too).
 
@@ -71,7 +71,6 @@ You may subscribe multiple times to the same room, with identical or different s
 
 ```json
 {
-  "error": null,
   "status": 200,
   "roomId": "ID of the room concerned by this notification",
   "requestId": "5897cd2f-a8a2-40b2-aa43-b31898172008",

--- a/src/sdk-reference/essentials/offline-first.md
+++ b/src/sdk-reference/essentials/offline-first.md
@@ -60,7 +60,7 @@ Additionally, almost all request methods accept a ``queuable`` option. If set to
 
 <aside class="warning">
 Setting <code>autoReplay</code> to <code>true</code> when using user authentication should generally be avoided.<br/>
-When leaving offline-mode, the JWT Token validity is verified. If it has expired, the token will be removed and a <code>jwtTokenExpired</code> event will be triggered.<br/>
+When leaving offline-mode, the JWT validity is verified. If it has expired, the token will be removed and a <code>tokenExpired</code> event will be triggered.<br/>
 If <code>autoReplay</code> is set, then all pending requests will be automatically played as an anonymous user.
 </aside>
 

--- a/src/sdk-reference/kuzzle/add-listener.md
+++ b/src/sdk-reference/kuzzle/add-listener.md
@@ -30,8 +30,8 @@ kuzzle.addListener(Event.connected, eventListener);
 ```php
 <?php
 
-$kuzzle->addListener('jwtTokenExpired', function() {
-  // Actions to perform when receiving a 'jwtTokenExpired' global event
+$kuzzle->addListener('queryError', function() {
+  // Actions to perform when receiving a 'queryError' global event
 });
 
 ```

--- a/src/sdk-reference/kuzzle/remove-all-listeners.md
+++ b/src/sdk-reference/kuzzle/remove-all-listeners.md
@@ -32,8 +32,8 @@ use \Kuzzle\Kuzzle;
 
 $kuzzle = new Kuzzle('localhost');
 
-// Removes all listeners on the "jwtTokenExpired" global event
-$kuzzle->removeAllListeners('jwtTokenExpired');
+// Removes all listeners on the "queryError" global event
+$kuzzle->removeAllListeners('queryError');
 
 // Removes all listeners on all global events
 $kuzzle->removeAllListeners();

--- a/src/sdk-reference/kuzzle/remove-listener.md
+++ b/src/sdk-reference/kuzzle/remove-listener.md
@@ -24,7 +24,7 @@ use \Kuzzle\Kuzzle;
 
 $kuzzle = new Kuzzle('localhost');
 
-$kuzzle->removeListener('jwtTokenExpired', $callback);
+$kuzzle->removeListener('queryError', $callback);
 ```
 
 Removes a listener from an event.


### PR DESCRIPTION
# Description

- Change notification examples to new format
- Document the new `notify:[document|user|server|dispatch]` plugin events
- remove obsolete MQTT code example (was still using RabbitMQ)
- rework of the Guide/Essentials/Real-time Notifications part
- rename the `jwtTokenExpired` SDK event to `tokenExpired`


# Boyscout

- PHP SDK: addListener/removeListener/removeAllListeners example now use an actually implemented event
- The request life-cycle documentation now use an up-to-date (and existing) controller-action pair
