### PR TITLE
Standardizes _meta location across Kuzzle

### DIFF
--- a/src/api-documentation/controller-document/get.md
+++ b/src/api-documentation/controller-document/get.md
@@ -58,6 +58,10 @@ title: get
       },
       "hobby": "Segway polo",
       ...
+    },
+    "_meta": {
+      "author": "Bob",
+      ...
     }
   }
 }

--- a/src/api-documentation/controller-document/m-create-or-replace.md
+++ b/src/api-documentation/controller-document/m-create-or-replace.md
@@ -30,7 +30,7 @@ title: mCreateOrReplace
       }
     },
     {
-      "_id": "<anotherDocumentId>" // Mandatory
+      "_id": "<anotherDocumentId>", // Mandatory
       "body": {
         "document": "body",
         ...
@@ -97,15 +97,15 @@ title: mCreateOrReplace
           "total": 2
         },
         "_source": {
-          "_meta": {
-            "active": true,
-            "author": "-1",
-            "createdAt": 1484226104822,
-            "deletedAt": null,
-            "updatedAt": null,
-            "updater": null
-          },
           "document": "body"
+        },
+        "_meta": {
+          "active": true,
+          "author": "-1",
+          "createdAt": 1484226104822,
+          "deletedAt": null,
+          "updatedAt": null,
+          "updater": null
         },
         "_type": "<collection>",
         "_version": 2,
@@ -121,15 +121,15 @@ title: mCreateOrReplace
           "total": 2
         },
         "_source": {
-          "_meta": {
-            "active": true,
-            "author": "-1",
-            "createdAt": 1484226104822,
-            "deletedAt": null,
-            "updatedAt": null,
-            "updater": null
-          },
           "document": "body"
+        },
+        "_meta": {
+          "active": true,
+          "author": "-1",
+          "createdAt": 1484226104822,
+          "deletedAt": null,
+          "updatedAt": null,
+          "updater": null
         },
         "_type": "<collection>",
         "_version": 2,

--- a/src/api-documentation/controller-document/m-create.md
+++ b/src/api-documentation/controller-document/m-create.md
@@ -30,7 +30,7 @@ title: mCreate
       }
     },
     {
-      "_id": "<anotherDocumentId>" // Optional. If not provided, will be generated automatically.
+      "_id": "<anotherDocumentId>", // Optional. If not provided, will be generated automatically.
       "body": {
         "document": "body",
         ...
@@ -96,15 +96,15 @@ title: mCreate
           "total": 2
         },
         "_source": {
-          "_meta": {
-            "active": true,
-            "author": "-1",
-            "createdAt": 1484225532686,
-            "deletedAt": null,
-            "updatedAt": null,
-            "updater": null
-          },
           "document": "body"
+        },
+        "_meta": {
+          "active": true,
+          "author": "-1",
+          "createdAt": 1484225532686,
+          "deletedAt": null,
+          "updatedAt": null,
+          "updater": null
         },
         "_type": "<collection>",
         "_version": 1,
@@ -120,15 +120,15 @@ title: mCreate
           "total": 2
         },
         "_source": {
-          "_meta": {
-            "active": true,
-            "author": "-1",
-            "createdAt": 1484225532686,
-            "deletedAt": null,
-            "updatedAt": null,
-            "updater": null
-          },
           "document": "body"
+        },
+        "_meta": {
+          "active": true,
+          "author": "-1",
+          "createdAt": 1484225532686,
+          "deletedAt": null,
+          "updatedAt": null,
+          "updater": null
         },
         "_type": "<collection>",
         "_version": 1,

--- a/src/api-documentation/controller-document/m-get.md
+++ b/src/api-documentation/controller-document/m-get.md
@@ -62,15 +62,15 @@ title: mGet
         "_id": "<documentId>",
         "_index": "<index>",
         "_source": {
-          "_meta": {
-            "active": true,
-            "author": "-1",
-            "createdAt": 1484226562795,
-            "deletedAt": null,
-            "updatedAt": null,
-            "updater": null
-          },
           "some": "body"
+        },
+        "_meta": {
+          "active": true,
+          "author": "-1",
+          "createdAt": 1484226562795,
+          "deletedAt": null,
+          "updatedAt": null,
+          "updater": null
         },
         "_type": "<collection>",
         "_version": 4,
@@ -80,15 +80,15 @@ title: mGet
         "_id": "<anotherDocumentId>",
         "_index": "<index>",
         "_source": {
-          "_meta": {
-            "active": true,
-            "author": "-1",
-            "createdAt": 1484226562795,
-            "deletedAt": null,
-            "updatedAt": null,
-            "updater": null
-          },
           "some": "body"
+        },
+        "_meta": {
+          "active": true,
+          "author": "-1",
+          "createdAt": 1484226562795,
+          "deletedAt": null,
+          "updatedAt": null,
+          "updater": null
         },
         "_type": "<collection>",
         "_version": 4,

--- a/src/api-documentation/controller-document/m-replace.md
+++ b/src/api-documentation/controller-document/m-replace.md
@@ -30,7 +30,7 @@ title: mReplace
       }
     },
     {
-      "_id": "<anotherDocumentId>" // Mandatory
+      "_id": "<anotherDocumentId>", // Mandatory
       "body": {
         "document": "body",
         ...
@@ -97,15 +97,15 @@ title: mReplace
           "total": 2
         },
         "_source": {
-          "_meta": {
-            "active": true,
-            "author": "-1",
-            "createdAt": 1484226104822,
-            "deletedAt": null,
-            "updatedAt": null,
-            "updater": null
-          },
           "document": "body"
+        },
+        "_meta": {
+          "active": true,
+          "author": "-1",
+          "createdAt": 1484226104822,
+          "deletedAt": null,
+          "updatedAt": null,
+          "updater": null
         },
         "_type": "<collection>",
         "_version": 2,
@@ -121,15 +121,15 @@ title: mReplace
           "total": 2
         },
         "_source": {
-          "_meta": {
-            "active": true,
-            "author": "-1",
-            "createdAt": 1484226104822,
-            "deletedAt": null,
-            "updatedAt": null,
-            "updater": null
-          },
           "document": "body"
+        },
+        "_meta": {
+          "active": true,
+          "author": "-1",
+          "createdAt": 1484226104822,
+          "deletedAt": null,
+          "updatedAt": null,
+          "updater": null
         },
         "_type": "<collection>",
         "_version": 2,

--- a/src/api-documentation/controller-document/m-update.md
+++ b/src/api-documentation/controller-document/m-update.md
@@ -30,7 +30,7 @@ title: mUpdate
       }
     },
     {
-      "_id": "<anotherDocumentId>" // Mandatory
+      "_id": "<anotherDocumentId>", // Mandatory
       "body": {
         "partial": "body",
         ...

--- a/src/api-documentation/controller-document/replace.md
+++ b/src/api-documentation/controller-document/replace.md
@@ -60,6 +60,9 @@ title: replace
     "_source": { // The resulting document
       ...
     },
+    "_meta": {
+      ...
+    },
     "_version": "<number>",// The new version number of this document
     "created": false
   }

--- a/src/guide/essentials/persisted.md
+++ b/src/guide/essentials/persisted.md
@@ -68,15 +68,15 @@ Notice that the document is associated to the auto-generated id `AVkDBl3YsT6qHI7
     },
     "created": true,
     "_source": {
-      "message": "Hello, world!",
-      "_meta": {
-        "author": "-1",
-        "createdAt": 1481814465050,
-        "updatedAt": null,
-        "updater": null,
-        "active": true,
-        "deletedAt": null
-      }
+      "message": "Hello, world!"
+    },
+    "_meta": {
+      "author": "-1",
+      "createdAt": 1481814465050,
+      "updatedAt": null,
+      "updater": null,
+      "active": true,
+      "deletedAt": null
     }
   }
 }

--- a/src/sdk-reference/collection/search.md
+++ b/src/sdk-reference/collection/search.md
@@ -243,15 +243,13 @@ Executes a search on the data collection.
 
 ## Processing large data sets
 
-When processing a large number of documents (i.e. more than 1000), using `search` requests only are not the best option.
+When processing a large number of documents (i.e. more than 1000), using `search` requests only is not the best option.
 
-Pagination of results can be done by using the from and size but the cost becomes prohibitive when the deep pagination is reached. In fact, Elasticsearch, the database Kuzzle is relying on, prevents to go beyond than 10000 results by default.
+Pagination of results can be done by using the from and size but the cost becomes prohibitive when the deep pagination is reached. In fact, Elasticsearch, the database Kuzzle is relying on, prevents going beyond 10,000 results by default.
 
 Instead, the recommended way to process a large number of documents is to use [`Collection.scroll`]({{ site_base_path }}sdk-reference/collection/scroll/) or, easier, [`SearchResult.fetchNext`]({{ site_base_path }}sdk-reference/search-result/fetch-next).
 
-See [`SearchResult.fetchNext`]({{ site_base_path }}sdk-reference/search-result/fetch-next/#how-to-process-all-documents-from-a-collection) for an example of how to process all documents from a collection.
-
-
+See [`SearchResult.fetchNext`]({{ site_base_path }}sdk-reference/search-result/fetch-next/#how-to-process-every-document-of-a-collection) for an example of how to process every document of a collection.
 
 ---
 

--- a/src/sdk-reference/search-result/fetch-next.md
+++ b/src/sdk-reference/search-result/fetch-next.md
@@ -63,12 +63,16 @@ Fetches the next SearchResult, by triggering a new search/scroll request dependi
 If the previous request was a search or a scroll action which provided a `scroll` argument,
 `fetchNext` will use the `scrollId` retrieved from the current result to make a new scroll request.
 
+If the previous request was a search action which provided `size` argument and `sort` filtering,
+`fetchNext` will use Elasticsearch's [`search_after`](https://www.elastic.co/guide/en/elasticsearch/reference/master/search-request-search-after.html) mechanism, which can efficiently search through a large volume of document, bypassing internal hard limits<sup>\[1\]</sup>,
+but at the cost of reflecting the latest changes of the index, as opposed to using scroll.
+
 If the previous request was a search action which provided `from` and `size` arguments,
 `fetchNext` will add `size` to `from` and make a new search request.
 
 ---
 
-## How to process all documents from a collection
+## How to process every document of a collection
 
 ```js
 var processDocument = function (document) {
@@ -98,7 +102,6 @@ kuzzle
 ```java
 import io.kuzzle.sdk.core.Kuzzle;
 import io.kuzzle.sdk.core.Options;
-
 
 Kuzzle kuzzle = new Kuzzle("localhost");
 
@@ -174,4 +177,4 @@ The safest way to process all documents in a collection is to retrieve them by b
 
 <aside class="warning">Make sure your first search request includes <code>size</code> and <code>scroll</code> parameters</aside>
 
-<aside class="notice"><sup>\[1\]</sup> Elasticsearch limits the number of documents inside a single page to [10000 by default](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#dynamic-index-settings).</aside>
+<aside class="notice"><sup>\[1\]</sup> Elasticsearch limits the number of documents inside a single page to [10,000 by default](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#dynamic-index-settings).</aside>


### PR DESCRIPTION
## Introduces
- Updated docs to reflect changes in _meta location in Kuzzle responses ([PR on Kuzzle side](https://github.com/kuzzleio/kuzzle/pull/888))
- fetchNext documentation update to explain use case differences between scroll, search_after & from/size searches

## Boyscoot
- Typos