### PR TITLE
Fix outdated room:new event payload

### DIFF
--- a/src/kuzzle-events/room/index.md
+++ b/src/kuzzle-events/room/index.md
@@ -12,5 +12,5 @@ Events triggered on subscription rooms activity.
 
 | Event | Type | Description | Payload |
 |-------|------|-------------|---------|
-| `room:new` | Pipe | Triggered when a new room is added in the rooms list. You can't modify the input on this event | Type: Object. <br> `{roomId, index, collection, formattedFilters}` |
+| `room:new` | Pipe | Triggered when a new room is added in the rooms list. You can't modify the input on this event | Type: Object. <br> `{roomId, index, collection}` |
 | `room:remove` | Pipe | Triggered after a room is removed from the list. You can't modify the input on this event | Type: String.<br> The room id |


### PR DESCRIPTION
# Description

The `formattedFilters` part of the `room:new` event payload was left undefined since DSL engine v2, so that event's documentation was outdated.