### PR TITLE
Fix return type for MemoryStorage:Renamenx

### DIFF
--- a/src/api-documentation/controller-memory-storage/expire.md
+++ b/src/api-documentation/controller-memory-storage/expire.md
@@ -61,7 +61,7 @@ title: expire
   "collection": null,
   "index": null,
   "volatile": null,
-  "result": "[0|1]" // success status
+  "result": [0|1] // success status
 }
 ```
 

--- a/src/api-documentation/controller-memory-storage/expireat.md
+++ b/src/api-documentation/controller-memory-storage/expireat.md
@@ -58,7 +58,7 @@ title: expireat
   "collection": null,
   "index": null,
   "volatile": null,
-  "result": "[0|1]" // success status
+  "result": [0|1] // success status
 }
 ```
 

--- a/src/api-documentation/controller-memory-storage/hexists.md
+++ b/src/api-documentation/controller-memory-storage/hexists.md
@@ -46,7 +46,7 @@ title: hexists
   "collection": null,
   "index": null,
   "volatile": null,
-  "result": "[0|1]"
+  "result": [0|1]
 }
 ```
 

--- a/src/api-documentation/controller-memory-storage/hsetnx.md
+++ b/src/api-documentation/controller-memory-storage/hsetnx.md
@@ -60,7 +60,7 @@ title: hsetnx
   "collection": null,
   "index": null,
   "volatile": null,
-  "result": "[0|1]"
+  "result": [0|1]
 }
 ```
 

--- a/src/api-documentation/controller-memory-storage/pexipre.md
+++ b/src/api-documentation/controller-memory-storage/pexipre.md
@@ -59,7 +59,7 @@ title: pexpire
   "collection": null,
   "index": null,
   "volatile": null,
-  "result": "[0|1]"
+  "result": [0|1]
 }
 ```
 

--- a/src/api-documentation/controller-memory-storage/pexpireat.md
+++ b/src/api-documentation/controller-memory-storage/pexpireat.md
@@ -59,7 +59,7 @@ title: pexpireat
   "collection": null,
   "index": null,
   "volatile": null,
-  "result": "[0|1]"
+  "result": [0|1]
 }
 ```
 

--- a/src/api-documentation/controller-memory-storage/pfadd.md
+++ b/src/api-documentation/controller-memory-storage/pfadd.md
@@ -59,7 +59,7 @@ title: pfadd
   "collection": null,
   "index": null,
   "volatile": null,
-  "result": "[0|1]"
+  "result": [0|1]
 }
 ```
 

--- a/src/api-documentation/controller-memory-storage/renamenx.md
+++ b/src/api-documentation/controller-memory-storage/renamenx.md
@@ -59,7 +59,7 @@ title: renamenx
   "collection": null,
   "index": null,
   "volatile": null,
-  "result": "OK"
+  "result": [0|1]
 }
 ```
 

--- a/src/api-documentation/controller-memory-storage/setnx.md
+++ b/src/api-documentation/controller-memory-storage/setnx.md
@@ -59,7 +59,7 @@ title: setnx
   "collection": null,
   "index": null,
   "volatile": null,
-  "result": "[0|1]"
+  "result": [0|1]
 }
 ```
 

--- a/src/api-documentation/controller-memory-storage/sismember.md
+++ b/src/api-documentation/controller-memory-storage/sismember.md
@@ -47,7 +47,7 @@ title: sismember
   "collection": null,
   "index": null,
   "volatile": null,
-  "result": "[0|1]"
+  "result": [0|1]
 }
 ```
 

--- a/src/api-documentation/controller-memory-storage/smove.md
+++ b/src/api-documentation/controller-memory-storage/smove.md
@@ -61,7 +61,7 @@ title: smove
   "collection": null,
   "index": null,
   "volatile": null,
-  "result": "[0|1]"
+  "result": [0|1]
 }
 ```
 

--- a/src/sdk-reference/memory-storage/renamenx.md
+++ b/src/sdk-reference/memory-storage/renamenx.md
@@ -24,9 +24,9 @@ kuzzle.memoryStorage.renamenxPromise('key', 'newId')
 ```
 
 ```java
-kuzzle.memoryStorage.renamenx("key", "newId", new ResponseListener<String>() {
+kuzzle.memoryStorage.renamenx("key", "newId", new ResponseListener<Integer>() {
   @Override
-  public void onSuccess(String status) {
+  public void onSuccess(int status) {
     // callback called once the action has completed
   }
 
@@ -55,7 +55,7 @@ catch (ErrorException $e) {
 > Callback response:
 
 ```json
-"OK"
+1
 ```
 
 Renames a key to `newkey`, only if `newkey` does not already exist.
@@ -92,4 +92,4 @@ Returns the `MemoryStorage` object to allow chaining.
 
 ## Callback response
 
-Resolves to a simple "OK" string.
+Resolves to an integer indicating if the insertion succeeded (`1`) or failed (`0`).


### PR DESCRIPTION
The renamenx should return a boolean (success|failure) instead of a status string ("OK")

Android update PR: https://github.com/kuzzleio/sdk-android/pull/149