### PR TITLE
Add link from controller plugins to plugin events documentations

### DIFF
--- a/src/plugins-reference/plugins-features/adding-controllers.md
+++ b/src/plugins-reference/plugins-features/adding-controllers.md
@@ -61,6 +61,14 @@ All action functions receive a [Request]({{ site_base_path }}plugins-reference/p
 
 ---
 
+## Automatic events generation
+
+Kuzzle triggers events on all controller routes, and those added by plugins make no exception.  
+More on these automatic controller events [here]({{ site_base_path }}kuzzle-events/plugin-events/).
+
+
+---
+
 ## TL;DR plugin skeleton
 
 ```javascript


### PR DESCRIPTION
# Description

The controller plugins documentation does not explicitly state that Kuzzle automatically add events on custom routes, even if a page dedicated to plugin events exists inside the Kuzzle Events documentation.

This PR adds a small paragraph in the controller plugins documentation pointing to the one in Kuzzle Events, to make this capability apparent to plugin developers.

# Solved issue

#349 
