### PR TITLE
Fixed some examples

### DIFF
--- a/src/guide/essentials/user-authentication.md
+++ b/src/guide/essentials/user-authentication.md
@@ -9,6 +9,43 @@ order: 750
 
 Once [roles and profiles]({{ site_base_path }}guide/essentials/security) have been set, you can create users and allow them to authenticate themselves in different ways.
 
+## Perform a basic login
+
+The most simple way you can login to Kuzzle is via the `local` strategy, using the SDK. We'll use the NodeJS SDK here, but the process is similar for other languages.
+
+If you have no users in your Kuzzle Backend yet, you can read the documentation on [how to configure it for security]({{ site_base_path }}guide/essentials/security), or [create your first administrator using the backoffice](http://kuzzle-backoffice.netlify.com) (you don't even have to install it, it's available online).
+
+Create a `login.js` file, NPM-install the Kuzzle SDK and start coding:
+
+```javascript
+var Kuzzle = require('kuzzle-sdk')
+
+var kuzzle = new Kuzzle('localhost', () => {
+  kuzzle
+    .loginPromise('local', {
+      username: 'admin',
+      password: 'test'
+    })
+    .then(kuzzle => {
+      console.log('logged!')
+    })
+    .catch(err => {
+      console.error(err.message)
+    })
+})
+
+```
+
+Assuming that you have an `admin` user with `test` password in your Kuzzle Backoffice, the code above does the following:
+* loads the `Kuzzle` SDK from it NPM package,
+* instantiates the SDK by connecting it to the Kuzzle Backoffice running on `localhost`,
+* _after the SDK connected to Kuzzle Backend_, it performs a login for the `admin` user,
+* displays to console a success message or an error message whether the login has succeeded or failed.
+
+<aside class="notice">
+  It's very important that the `login` code executes after the SDK has successfully connected to the backend, since `login` is not a queuable method (queuable methods can be called before the SDK is connected to the backend and are automatically played once the connection is established). That's why we put all the `login` code in the constructor's callback.
+</aside>
+
 ---
 
 ## Authentication strategy

--- a/src/guide/essentials/user-authentication.md
+++ b/src/guide/essentials/user-authentication.md
@@ -26,7 +26,7 @@ var kuzzle = new Kuzzle('localhost', () => {
       username: 'admin',
       password: 'test'
     })
-    .then(kuzzle => {
+    .then(() => {
       console.log('logged!')
     })
     .catch(err => {

--- a/src/guide/getting-started/index.md
+++ b/src/guide/getting-started/index.md
@@ -91,7 +91,7 @@ Before proceeding, ensure that your system matches the following requisites:
 * A fairly recent version of **NodeJS** (i.e. v6+) should be installed on your system (<a href="https://nodejs.org/en/download/">instructions here</a>),
 * A Kuzzle server up and running.
 
-### Create your first "Hello World" document
+### Prepare your environment
 
 Create your playground directory and install the [Javascript SDK]({{ site_base_path }}sdk-reference) from the command line using npm:
 
@@ -103,27 +103,55 @@ cd "kuzzle-playground"
 npm install kuzzle-sdk
 ```
 
-Save the following JS code in the new `create.js` file:
+Then, create a `create.js` file and start coding:
 
 ```javascript
 var Kuzzle = require('kuzzle-sdk')
 
 // connect to the Kuzzle server
 var kuzzle = new Kuzzle('localhost', {
-    defaultIndex: 'playground'
+  defaultIndex: 'playground'
+})
+
+kuzzle
+  .createIndexPromise('playground')
+  .then(() => kuzzle.collection('mycollection').createPromise());
+```
+
+This code does the following:
+* loads the `Kuzzle` SDK from its NPM package,
+* creates an instance of the SDK and connects it to the Kuzzle Backoffice running on `localhost` (and selects the `playground` as default index),
+* creates the `playground` index,
+* creates the `mycollection` collection (within the `playground` index).
+
+You're now ready to say Hello to the World!
+
+### Create your first "Hello World" document
+
+Append the following instructions after the Promise returned by `collection().createPromise` resolved
+
+```javascript
+kuzzle
+  .createIndexPromise('playground')
+  .then(() => kuzzle.collection('mycollection').createPromise())
+  .then(() => kuzzle
+    .collection('mycollection')
+    .createDocumentPromise({
+        message: 'Hello, World!'
+    })
+  .then(res => {
+    console.log('the document has been successfully created')
+  })
+  .catch(err => {
+    console.error(err.message)
   })
 
-// get a reference to the a collection
-var collection = kuzzle.collection('mycollection')
-
-// define the document itself
-var document = {
-    message: 'Hello, world!'
-}
-
-// persist the document into the collection
-collection.createDocument(document)
 ```
+
+This code adds the following actions to the previous one:
+* creates a new document containing a message saying "Hello, World" in `mycollection` within the `playground` index,
+* logs a success message to the console if everything went fine,
+* logs an error message if any of the previous actions failed.
 
 Run your file in NodeJS
 

--- a/src/guide/getting-started/index.md
+++ b/src/guide/getting-started/index.md
@@ -134,8 +134,7 @@ Append the following instructions after the Promise returned by `collection().cr
 kuzzle
   .createIndexPromise('playground')
   .then(() => kuzzle.collection('mycollection').createPromise())
-  .then(() => kuzzle
-    .collection('mycollection')
+  .then((collection) => collection
     .createDocumentPromise({
         message: 'Hello, World!'
     })

--- a/src/guide/getting-started/index.md
+++ b/src/guide/getting-started/index.md
@@ -230,4 +230,5 @@ Now that you are started and operational with Kuzzle, you can fully leverage its
 
 * <a href="{{ site_base_path }}sdk-reference">taking a look at the SDK reference</a>;
 * <a href="{{ site_base_path }}kuzzle-dsl">mastering the Kuzzle DSL syntax</a> to create incredibly fine-grained and blazing-fast subscriptions;
-* <a href="{{ site_base_path }}guide/#security">learning how to manage users and set-up fine-grained permission rights</a>.
+* <a href="{{ site_base_path }}guide/essentials/user-authentication/#perform-a-basic-login">learning how to perform a login</a>;
+* <a href="{{ site_base_path }}guide/essentials/security/">learning how to manage users and set-up fine-grained permission rights</a>.

--- a/src/sdk-reference/kuzzle/login.md
+++ b/src/sdk-reference/kuzzle/login.md
@@ -80,7 +80,7 @@ If the login attempt fails, the `loginAttempt` event is fired with the following
 `{ success: false, error: 'error message' }`
 
 <aside class="notice">
-This method is non-queuable, meaning that during offline mode, it will be discarded and the callback will be called with an error.
+This method is non-queuable, meaning that during offline mode, it will be discarded and the callback will be called with an error. <a href="{{ site_base_path }}guide/essentials/user-authentication/#perform-a-basic-login">Learn more.</a>
 </aside>
 
 ---


### PR DESCRIPTION
* SDK playtime in the Getting Started section is aligned with the new SDK API.
* Added an example of basic login with the `local` strategy.