### PR TITLE
Add informations about document metadata and the trashcan area

### DIFF
--- a/src/api-documentation/controller-document/count.md
+++ b/src/api-documentation/controller-document/count.md
@@ -13,7 +13,7 @@ title: count
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/<index>/<collection>/_count`  
+**URL:** `http://kuzzle:7512/<index>/<collection>/_count[?includeTrash=<boolean>]`  
 **Method:** `POST`  
 **Body:**
 </p>
@@ -26,7 +26,10 @@ title: count
   // Use "query" instead of "filter" if you want to perform a query instead.
   "filter": {
     ...
-  }
+  },
+
+  // Optional arguments
+  "includeTrash": false
 }
 ```
 
@@ -71,3 +74,7 @@ title: count
 Given some filters, gets the number of matching documents from Kuzzle's data storage layer.
 
 Kuzzle uses the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/5.x/query-dsl.html) syntax.
+
+Optional arguments:
+
+- `includeTrash` makes Kuzzle also look for documents in the [trashcan]({{ site_base_path }}guide/essentials/document-metadata/)

--- a/src/api-documentation/controller-document/get.md
+++ b/src/api-documentation/controller-document/get.md
@@ -13,7 +13,7 @@ title: get
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/<index>/<collection>/<documentId>`  
+**URL:** `http://kuzzle:7512/<index>/<collection>/<documentId>[?includeTrash=<boolean>]`  
 **Method:** `GET`
 </p>
 </blockquote>
@@ -25,20 +25,22 @@ title: get
 </blockquote>
 
 
-```json
+```js
 {
   "index": "<index>",
   "collection": "<collection>",
   "controller": "document",
   "action": "get",
+  "_id": "<documentId>",
 
-  "_id": "<documentId>"
+  // Optional arguments
+  "includeTrash": false
 }
 ```
 
 >**Response**
 
-```javascript
+```js
 {
   "status": 200,
   "error": null,
@@ -71,3 +73,7 @@ title: get
 Given a `document id`, retrieves the corresponding document from the database.
 
 Only documents in the persistent data storage layer can be retrieved.
+
+Optional argument:
+
+* `includeTrash`: if set, Kuzzle will also look for the document in the [trashcan]({{ site_base_path }}guide/essentials/document-metadata/). Otherwise, if the document exists but is inactive, a [NotFound]({{ site_base_path }}api-documentation/errors/#notfounderror) error is returned

--- a/src/api-documentation/controller-document/m-get.md
+++ b/src/api-documentation/controller-document/m-get.md
@@ -13,7 +13,7 @@ title: mGet
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/<index>/<collection>/_mGet`  
+**URL:** `http://kuzzle:7512/<index>/<collection>/_mGet[?includeTrash=<boolean>]`  
 **Method:** `POST`  
 **Body:**
 </p>
@@ -22,7 +22,10 @@ title: mGet
 
 ```js
 {
-  "ids": ["<documentId>", "<anotherDocumentId>", ...]
+  "ids": ["<documentId>", "<anotherDocumentId>", ...],
+
+  // Optional arguments
+  "includeTrash": false
 }
 ```
 
@@ -109,3 +112,7 @@ Given `document ids`, retrieves the corresponding documents from the database.
 Only documents in the persistent data storage layer can be retrieved.
 
 Returns a [partial error]({{ site_base_path }}api-documentation/errors/#partialerror) (with status 206) if one or more document can not be retrieved.
+
+Optional arguments:
+
+- `includeTrash`: if set, documents in the [trashcan]({{ site_base_path }}guide/essentials/document-metadata/) will also be returned

--- a/src/api-documentation/controller-document/search.md
+++ b/src/api-documentation/controller-document/search.md
@@ -13,7 +13,7 @@ title: search
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/<index>/<collection>/_search[?from=0][&size=42][&scroll=<time to live>]`  
+**URL:** `http://kuzzle:7512/<index>/<collection>/_search[?from=0][&size=42][&scroll=<time to live>][&includeTrash=<boolean>]`  
 **Method:** `POST`  
 **Body:**
 </p>
@@ -28,7 +28,13 @@ title: search
   },
   "aggregations": {
     ...
-  }
+  },
+
+  // Optional arguments
+  "from": 0,
+  "size": 42,
+  "scroll": "1m",
+  "includeTrash": false
 }
 ```
 
@@ -111,6 +117,7 @@ Optional arguments:
 * `size` controls the maximum number of documents returned in the response
 * `from` is usually used with the `size` argument, and defines the offset from the first result you want to fetch
 * `scroll` allows to fetch large result sets, and it must be set with a [time duration](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#time-units). If set, a forward-only cursor will be created (and automatically destroyed at the end of the set duration), and its identifier will be returned in the `_scroll_id` property, along with the first page of results. This cursor can then be moved forward using the [`scroll` API action]({{ site_base_path }}api-documentation/controller-document/scroll)
+* `includeTrash` makes Kuzzle also look for documents in the [trashcan]({{ site_base_path }}guide/essentials/document-metadata/)
 
 <aside class="warning">
   <p>

--- a/src/guide/essentials/document-metadata.md
+++ b/src/guide/essentials/document-metadata.md
@@ -39,7 +39,7 @@ Added metadata can be viewed in document's `_meta` property:
 * `createdAt`: Timestamp of the document creation (create or replace), in Epoch-milliseconds format
 * `updatedAt`: Timestamp of the last document update in Epoch-milliseconds format, or `null` if no update has been made
 * `updater`: The updater [unique identifier]({{ site_base_path }}guide/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid), or `null` if no update has been made
-* `alive`: `true` until the document has been put in the trashcan
+* `active`: `true` until the document has been put in the trashcan
 * `deletedAt`: deletion timestamp, `null` until put in the trashcan
 
 ---

--- a/src/guide/essentials/document-metadata.md
+++ b/src/guide/essentials/document-metadata.md
@@ -1,0 +1,81 @@
+---
+layout: full.html
+algolia: true
+title: Document metadata
+order: 450
+---
+
+# Document metadata
+
+Whenever a document gets created, updated or deleted, Kuzzle adds metadata to it, providing information about its life-cycle.
+
+---
+
+## Overview
+
+Added metadata can be viewed in document's `_meta` property:
+
+```json
+{
+  "_index": "myindex",
+  "_type": "mycollection",
+  "_id": "AVkDLAdCsT6qHI7MxLz4",
+  "_score": 0.25811607,
+  "_source": {
+    "message": "Hey! Ho!"
+  },
+  "_meta": {
+    "author": "<kuid>",
+    "createdAt": 1481816934209,
+    "updatedAt": null,
+    "updater": null,
+    "active": true,
+    "deletedAt": null
+  }
+}
+```
+
+* `author`: The author [unique identifier]({{ site_base_path }}guide/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid)
+* `createdAt`: Timestamp of the document creation (create or replace), in Epoch-milliseconds format
+* `updatedAt`: Timestamp of the last document update in Epoch-milliseconds format, or `null` if no update has been made
+* `updater`: The updater [unique identifier]({{ site_base_path }}guide/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid), or `null` if no update has been made
+* `alive`: `true` until the document has been put in the trashcan
+* `deletedAt`: deletion timestamp, `null` until put in the trashcan
+
+---
+
+## Search queries
+
+Metadata can be queried like any other document properties:
+
+```json
+{
+  "query": {
+      "range": {
+          "_meta.createdAt": {
+            "lte": 1481816930000
+          }
+      }
+    }
+}
+```
+
+---
+
+## Documents deletion
+
+When a document gets deleted, Kuzzle first isolates it from other active documents, by putting in an area called the trashcan.
+
+Documents in the trashcan cannot be accessed, searched or counted, unless the `includeTrash` flag is set when invoking the corresponding API routes.
+
+---
+
+## Garbage collection
+
+On regular intervals, Kuzzle will permanently delete some documents in the trashcan, starting from documents having stayed the longest in that area.
+
+The garbage collector follows the following rules:
+
+* if Kuzzle is in [overloaded state]({{ site_base_path }}kuzzle-events/core/#core-overload) when garbage collection is about to start, or if Kuzzle enters that state during garbage collection, then it will be delayed and wait until Kuzzle is no longer overloaded
+* Its behavior is configured using the `services.garbageCollector` property in Kuzzle's [configuration file]({{ site_base_path }}guide/essentials/configuration/), namely how often it passes and how many documents are deleted per data collection
+* When Kuzzle is started, it will wait the configured delay before running the garbage collector for the first time

--- a/src/guide/essentials/persisted.md
+++ b/src/guide/essentials/persisted.md
@@ -353,101 +353,6 @@ Which gives, as a result, the following response:
 
 ---
 
-## Document metadata
-
-When you create or update a document, Kuzzle adds metadata. These metadata describe the life-cycle of the document.
-They are available in the `_meta` part of a document:
-
-```json
-{
-  "_index": "myindex",
-  "_type": "mycollection",
-  "_id": "AVkDLAdCsT6qHI7MxLz4",
-  "_score": 0.25811607,
-  "_source": {
-    "message": "Hey! Ho!"
-  },
-  "_meta": {
-    "author": "-1",
-    "createdAt": 1481816934209,
-    "updatedAt": null,
-    "updater": null,
-    "active": true,
-    "deletedAt": null
-  }
-}
-```
-
-* `author`: The author identifier
-* `createdAt`: The UNIX Timestamp of the document creation (create or replace)
-* `updatedAt`: The UNIX Timestamp of the last document update, or `null` if no update has been made
-* `updater`: The updater identifier, or `null` if no update has been made
-* `active`: Always `true` for now
-* `deletedAt`: Always `null` for now
-
-
-They can be used in search queries to filter and sort documents like a normal document field:
-
-```json
-{
-  "query": {
-      "range": {
-          "_meta.createdAt": {
-            "lte": 1481816930000
-          }
-      }
-    }
-}
-```
-
-Which gives, as a result, the following response:
-
-```json
-{
-  "status": 200,
-  "error": null,
-  "requestId": "<random unique request id>",
-  "controller": "document",
-  "action": "search",
-  "collection": "mycollection",
-  "index": "myindex",
-  "volatile": null,
-  "headers": {},
-  "result": {
-    "took": 6,
-    "timed_out": false,
-    "_shards": {
-      "total": 5,
-      "successful": 5,
-      "failed": 0
-    },
-    "hits": [
-      {
-        "_index": "myindex",
-        "_type": "mycollection",
-        "_id": "AVkDK9iNsT6qHI7MxLz3",
-        "_score": 0,
-        "_source": {
-          "message": "Hello, world!"
-        },
-        "_meta": {
-          "author": "-1",
-          "createdAt": 1481816922252,
-          "updatedAt": null,
-          "updater": null,
-          "active": true,
-          "deletedAt": null
-        }
-      }
-    ],
-    "total": 1,
-    "max_score": 0.25811607
-  }
-}
-```
-
----
-
 ## Document mapping
 
 As previously said, Kuzzle relies on Elasticsearch to persist documents. Elasticsearch uses a mapping internally to match a document field to a field type. This mapping is attached to a `collection` (a `type` in Elasticsearch terminology).
@@ -497,5 +402,6 @@ The syntax to use is the one defined by [Elasticsearch](https://www.elastic.co/g
 ## Where do we go from here?
 
 
-* Refer to the [Elasticsearch cookbook]({{ site_base_path }}elasticsearch-cookbook) to get more details on how querying works in Kuzzle.
-* Keep track of the changes on your documents via the [Real-time Notifications]({{ site_base_path }}guide/essentials/real-time).
+* Refer to the [Elasticsearch cookbook]({{ site_base_path }}elasticsearch-cookbook) to get more details on how querying works in Kuzzle
+* Get history information, put a document in the trashcan and recover it, using [document metadata]({{ site_base_path }}guide/essentials/document-metadata)
+* Keep track of the changes on your documents via the [Real-time Notifications]({{ site_base_path }}guide/essentials/real-time)


### PR DESCRIPTION
# Description

* Promoted the `Document metadata` paragraph in the `Working with persistent data` documentation as a standalone documentation
* Add information about "deleted" document been put in the trashcan
* Add information about the garbage collector
* Add the missing `includeTrash` flag in the following API route documentations: `document:get`, `document:mget`, `document:search` and `document:count`

# Solved issue

#63 

/ping @xbill82 
