### PR TITLE
Better documentation on how to create a new user 

### DIFF
--- a/src/api-documentation/controller-security/create-user.md
+++ b/src/api-documentation/controller-security/create-user.md
@@ -13,7 +13,6 @@ title: createUser
 {{{since "1.0.0"}}}
 
 
-
 <blockquote class="js">
 <p>
 **URL:** `http://kuzzle:7512/users/<kuid>/_create` or `http://kuzzle:7512/users/_create`  
@@ -25,7 +24,7 @@ title: createUser
 ```js
 {
   "content": {
-    "profileIds": ["<profileId>"],          // Mandatory. The profile ids for the user
+    "profileIds": ["<profileId>"],          // Required
     "name": "John Doe",                     // Additional optional User properties
     ...
   },
@@ -36,11 +35,11 @@ title: createUser
   }
 }
 
-// example with a "local" authentication
+// example with the "local" authentication strategy
 
 {
   "content": {
-    "profileIds": ["<profileId>"],          // Mandatory. The profile ids for the user
+    "profileIds": ["<profileId>"],          // Required
     "name": "John Doe",                     // Additional optional User properties
     ...
   },
@@ -129,6 +128,11 @@ Creates a new `user` in Kuzzle's database layer.
 If an `_id` is provided in the query and if a user [`<kuid>`]({{ site_base_path }}guide/essentials/user-authentication/#kuzzle-user-identifier-kuid) already exists, an error is returned.
 If not provided, the `_id` will be auto-generated.
 
-Provided profile ids are used to set the permissions of the user.
+The body content describes the user to be created, and it must have the following properties:
 
-Other mandatory additional information are needed in the `credentials` attribute depending on the installed authentication plugins you want to use.
+* `content` (JSON object): user global properties
+  * This object must contain a `profileIds` properties, an array of strings listing the [profiles]({{ site_base_path }}guide/essentials/security/#users-profiles-and-roles) to be attached to the new user 
+  * Any other property will be copied as additional global user information
+* `credentials` (JSON object): a description of how the new user can authentify himself to Kuzzle
+  * Any number of credentials can be added, each one being an object whose name is the one of the [authentication strategy]({{ site_base_path }}plugins-reference/plugins-features/adding-authentication-strategy/#expose-authentication-strategies) that can be used for authentification, and its content the necessary login information for that user
+  * If that object is left empty, the described user will be created by Kuzzle but (s)he  won't be able to log in

--- a/src/sdk-reference/security/create-user.md
+++ b/src/sdk-reference/security/create-user.md
@@ -11,19 +11,22 @@ title: createUser
 # createUser
 
 ```js
-var userContent = {
+var user = {
   content: {
-    // A "profile" field is required to bind a user to an existing profile
+    // A "profileIds" field is required to bind a user to existing profiles
     profileIds: ['admin'],
+
+    // Additional information may be provided
     firstname: 'John',
     lastname: 'Doe'
   },
   credentials: {
-    local: {
-      // The "local" authentication strategy requires a password
-      password: 'secretPassword',
-      // You can also set custom fields to your user
-      lastLoggedIn: 1494411803
+    // Authentication strategy to use
+    "local": {
+      // The necessary information to provide vary,
+      // depending on the chosen authentication strategy
+      "username": "jdoe",
+      "password": "secret password"
     }
   }
 };
@@ -34,22 +37,22 @@ var options = {};
 // Using callbacks (NodeJS or Web Browser)
 kuzzle
   .security
-  .createUser('myuser', userContent, options, function(error, response) {
+  .createUser('myuser', user, options, function(error, response) {
     // result is a User object
   });
 
 // Using promises (NodeJS)
 kuzzle
   .security
-  .createUserPromise('myuser', userContent, options)
-  .then((response) => {
+  .createUserPromise('myuser', user, options)
+  .then(response => {
     // result is a User object
   });
 ```
 
 ```java
 JSONObject content = new JSONObject()
-  // A "profile" field is required to bind a user to existing profiles
+  // A "profileIds" field is required to bind a user to existing profiles
   .put("profileIds", new JSONArray()
     .put("admin")
   )
@@ -60,10 +63,12 @@ JSONObject content = new JSONObject()
 JSONObject newUser = new JSONObject().put("content", content);
 
 JSONObject credentials = new JSONObject()
+  // Authentication strategy to use
   .put("local", new JSONObject()
-    // The "local" authentication strategy requires a password
+    // The necessary information to provide vary,
+    // depending on the chosen authentication strategy
     .put("password", "secret password")
-    .put("lastLoggedIn", 1494411803)
+    .put("username", "jdoe")
   );
 
 newUser.put("credentials", credentials);
@@ -94,17 +99,19 @@ use \Kuzzle\Security\User;
 $kuid = 'myUser';
 $userDefinition = [
     'content' => [
-      // A "profile" field is required to bind a user to an existing profile
+      // A "profileIds" field is required to bind a user to existing profiles
       'profileIds' => ['admin'],
       // You can also set custom fields to your user
       'firstname' => 'John',
       'lastname' => 'Doe'
     ],
     'credentials' => [
+      // Authentication strategy to use
       'local' => [
-        // The "local" authentication strategy requires a password
-        'password' => 'secretPassword',
-        'lastLoggedIn' => 1494411803
+        // The necessary information to provide vary,
+        // depending on the chosen authentication strategy
+        'password' => 'secret password',
+        'username' => 'jdoe'
       ]
     ]
   ];
@@ -126,19 +133,29 @@ Create a new user in Kuzzle.
 
 <aside class="notice">
 There is a small delay between user creation and their creation in our search layer, usually a couple of seconds.
-That means that a user that was just been created will not be returned by <code>searchUsers</code> function
+That means that a user that was just been created will not be returned by <code>searchUsers</code> right away
 </aside>
 
 ---
 
-## createUser(id, content, [options], [callback])
+## createUser(id, user, [options], [callback])
 
 | Arguments | Type | Description |
 |---------------|---------|----------------------------------------|
-| ``id`` | string | Unique user identifier, will be used as username |
-| ``content`` | JSON Object | A plain JSON object representing the user |
+| ``id`` | string | [Unique user identifier]({{ site_base_path }}guide/kuzzle-depth/authentication/#the-kuzzle-user-identifier-kuid) |
+| ``user`` | JSON Object | A plain JSON object representing the user (see below) |
 | ``options`` | string | (Optional) Optional arguments |
 | ``callback`` | function | Callback handling the response |
+
+
+The `user` object to provide must have the following properties:
+
+* `content` (JSON object): user global properties
+  * This object must contain a `profileIds` properties, an array of strings listing the [profiles]({{ site_base_path }}guide/essentials/security/#users-profiles-and-roles) to be attached to the new user 
+  * Any other property will be copied as additional global user information
+* `credentials` (JSON object): a description of how the new user can authentify himself to Kuzzle
+  * Any number of credentials can be added, each one being an object whose name is the one of the [authentication strategy]({{ site_base_path }}plugins-reference/plugins-features/adding-authentication-strategy/#expose-authentication-strategies) that can be used for authentification, and its content the necessary login information for that user
+  * If that object is left empty, the described user will be created by Kuzzle but (s)he  won't be able to log in
 
 ---
 


### PR DESCRIPTION
# Description

The `createUser` method documentation in the SDK reference says too little about how to create a new user. This PR fixes that, and the API eponym route documentation has also been improved

# Solved issue

#317 
