### PR TITLE
Fix left menu default scrolling

### DIFF
--- a/src/assets/javascript/ux-left-nav.js
+++ b/src/assets/javascript/ux-left-nav.js
@@ -1,12 +1,17 @@
 (function leftNavUX() {
+console.log('leftNavUx');
   var $wrapper = $('.tocify-wrapper');
 
+console.log('Wrap length', $wrapper.length);
   if ($wrapper.length !== 0) {
     var $selectedItem = $('.tocify-level-2.tocify-focus', $wrapper);
 
     if ($selectedItem.length === 0) {
       $selectedItem = $('.tocify-focus', $wrapper);
     }
+console.log('selectedItem', $selectedItem);
+console.log('selectedItem Offset', $selectedItem.get(0).offsetTop + 120);
+console.log('wrapper heigth', $wrapper.height());
 
     if ($selectedItem.get(0).offsetTop + 120 > $wrapper.height()) {
       $wrapper.scrollTop(Math.ceil($selectedItem.get(0).offsetTop - $wrapper.height() / 2));

--- a/src/assets/javascript/ux-left-nav.js
+++ b/src/assets/javascript/ux-left-nav.js
@@ -4,17 +4,19 @@ console.log('leftNavUx');
 
 console.log('Wrap length', $wrapper.length);
   if ($wrapper.length !== 0) {
-    var $selectedItem = $('.tocify-level-2.tocify-focus', $wrapper);
+    var $selectedItemList = $('.tocify-level-2.tocify-focus', $wrapper);
 
-    if ($selectedItem.length === 0) {
-      $selectedItem = $('.tocify-focus', $wrapper);
+    if ($selectedItemList.length === 0) {
+      $selectedItemList = $('.tocify-focus', $wrapper);
     }
-console.log('selectedItem', $selectedItem);
-console.log('selectedItem Offset', $selectedItem.get(0).offsetTop + 120);
+console.log('selectedItemList', $selectedItemList);
+    var $selectedItem = $selectedItemList.get($selectedItemList.length-1)
+console.log('selectedItem Offset', $selectedItem.offsetTop);
 console.log('wrapper heigth', $wrapper.height());
 
-    if ($selectedItem.get(0).offsetTop + 120 > $wrapper.height()) {
-      $wrapper.scrollTop(Math.ceil($selectedItem.get(0).offsetTop - $wrapper.height() / 2));
+    if ($selectedItem.offsetTop + 120 > $wrapper.height()) {
+      console.log(Math.ceil($selectedItem.offsetTop - $wrapper.height() / 2));
+      $wrapper.scrollTop(Math.ceil($selectedItem.offsetTop - $wrapper.height() / 2));
     }
   }
 

--- a/src/assets/javascript/ux-left-nav.js
+++ b/src/assets/javascript/ux-left-nav.js
@@ -1,21 +1,15 @@
 (function leftNavUX() {
-console.log('leftNavUx');
   var $wrapper = $('.tocify-wrapper');
 
-console.log('Wrap length', $wrapper.length);
   if ($wrapper.length !== 0) {
     var $selectedItemList = $('.tocify-level-2.tocify-focus', $wrapper);
 
     if ($selectedItemList.length === 0) {
       $selectedItemList = $('.tocify-focus', $wrapper);
     }
-console.log('selectedItemList', $selectedItemList);
     var $selectedItem = $selectedItemList.get($selectedItemList.length-1)
-console.log('selectedItem Offset', $selectedItem.offsetTop);
-console.log('wrapper heigth', $wrapper.height());
 
     if ($selectedItem.offsetTop + 120 > $wrapper.height()) {
-      console.log(Math.ceil($selectedItem.offsetTop - $wrapper.height() / 2));
       $wrapper.scrollTop(Math.ceil($selectedItem.offsetTop - $wrapper.height() / 2));
     }
   }

--- a/src/assets/stylesheets/_header.scss
+++ b/src/assets/stylesheets/_header.scss
@@ -74,10 +74,8 @@ header {
     padding: 2em $header-padding;
     background-color: #FFF;
 
-    @media (max-width: $desktop-width) {
-      padding: 1em 2em;
-      height: 75px;
-    }
+    padding: 1em 2em;
+    height: 75px;
 
     @media (max-width: $tablet-width) {
       height: auto;
@@ -91,13 +89,8 @@ header {
     }
 
     .logo img {
-      width: 110px;
-      margin-right: 3em;
-
-      @media (max-width: $desktop-width) {
-        width: 90px;
-          margin: 5px 5px 5px 0;
-      }
+      width: 90px;
+        margin: 5px 5px 5px 0;
     }
 
     a {
@@ -107,14 +100,10 @@ header {
     h1 {
       display: inline-block;
       vertical-align: top;
-      font-size: 2.2em;
+      font-size: 1.8em;
+      padding-top: 3px;
       color: #adadad;
       font-weight: 100;
-
-      @media (max-width: $desktop-width) {
-        font-size: 1.8em;
-        padding-top: 3px;
-      }
     }
 
     .search {
@@ -122,9 +111,7 @@ header {
       float: right;
       position: relative;
 
-      @media (max-width: $desktop-width) {
-        margin-top: 5px;
-      }
+      margin-top: 5px;
 
       @media (max-width: $tablet-width) {
         position: absolute;
@@ -141,17 +128,12 @@ header {
       &:after {
         display: inline-block;
         font: normal normal normal 13px/1 FontAwesome;
-        font-size: 1.2em;
+        font-size: 90%;
         text-rendering: auto;
         content: "\f002";
         right: 10px;
-        top: 8px;
+        top: 10px;
         position: absolute;
-
-        @media (max-width: $desktop-width) {
-          font-size: 90%;
-          top: 10px;
-        }
 
         @media (max-width: $phone-width) {
           color: #FFF;
@@ -406,9 +388,7 @@ header {
             padding-left: 0;
           }
 
-          @media (max-width: $desktop-width) {
-            padding: 11px 0px;
-          }
+          padding: 11px 0px;
 
           &.item-cookbooks {
             i {
@@ -447,13 +427,9 @@ header {
       button {
         background: $color-pinkpanther;
         border: none;
-        padding: 1em;
+        padding: 11px;
         @include nav-font;
         margin: 0 0 0 5px;
-
-        @media (max-width: $desktop-width) {
-          padding: 11px;
-        }
       }
     }
   }

--- a/src/assets/stylesheets/_header.scss
+++ b/src/assets/stylesheets/_header.scss
@@ -70,7 +70,7 @@ header {
   box-shadow: rgba(0, 0, 0, 0.1) 0 0 9px;
   width: 100%;
   position: fixed;
-  z-index: 1;
+  z-index: 2;
 
   .wrapper {
     padding: 2em $header-padding;

--- a/src/assets/stylesheets/_header.scss
+++ b/src/assets/stylesheets/_header.scss
@@ -92,7 +92,7 @@ header {
 
     .logo img {
       width: 90px;
-        margin: 5px 5px 5px 0;
+      margin: 5px 5px 5px 0;
     }
 
     a {

--- a/src/assets/stylesheets/_header.scss
+++ b/src/assets/stylesheets/_header.scss
@@ -69,6 +69,8 @@ header {
   background-color: $dark;
   box-shadow: rgba(0, 0, 0, 0.1) 0 0 9px;
   width: 100%;
+  position: fixed;
+  z-index: 1;
 
   .wrapper {
     padding: 2em $header-padding;

--- a/src/assets/stylesheets/_layout.scss
+++ b/src/assets/stylesheets/_layout.scss
@@ -6,6 +6,7 @@
     position: relative;
     margin-left: $nav-width;
     min-height: 100%;
+    padding-top: $header-height;
     padding-bottom: 1px; // prevent margin overflow
 
         .content {
@@ -17,5 +18,5 @@
             }
         }
     }
-     
+
 }

--- a/src/assets/stylesheets/_toc.scss
+++ b/src/assets/stylesheets/_toc.scss
@@ -185,5 +185,8 @@
 .container {
   .tocify-wrapper {
     top: $header-height;
+    @media (max-width: $phone-width) {
+      top: $header-height-phone;
+    }
   }
 }

--- a/src/assets/stylesheets/_toc.scss
+++ b/src/assets/stylesheets/_toc.scss
@@ -184,6 +184,6 @@
 
 .container {
   .tocify-wrapper {
-    top: 125px;
+    top: $header-height;
   }
 }

--- a/src/assets/stylesheets/_toc.scss
+++ b/src/assets/stylesheets/_toc.scss
@@ -7,7 +7,7 @@
   bottom: 0;
 
   width: $nav-width;
-  padding: 3em 0 0 4em;
+  padding: 1em 0 0 4em;
 
   overflow-y: auto;
   overflow-x: hidden;

--- a/src/assets/stylesheets/_toc.scss
+++ b/src/assets/stylesheets/_toc.scss
@@ -1,6 +1,10 @@
 .tocify-wrapper {
-  position: absolute;
+  position: fixed;
   z-index: 1;
+
+  top: 0;
+  left: 0;
+  bottom: 0;
 
   width: $nav-width;
   min-height: 100%;
@@ -14,7 +18,6 @@
   box-shadow: rgba(0,0,0,0.1) 0 0 9px;
 
   transition: left 0.3s ease-in-out;
-  overflow: visible;
 
   // The Table of Contents is composed of multiple nested
   // unordered lists.  These styles remove the default
@@ -177,5 +180,11 @@
     position: absolute;
     top: 16.5px;
     left: 16.5px;
+  }
+}
+
+.container {
+  .tocify-wrapper {
+    top: 240px;
   }
 }

--- a/src/assets/stylesheets/_toc.scss
+++ b/src/assets/stylesheets/_toc.scss
@@ -7,7 +7,6 @@
   bottom: 0;
 
   width: $nav-width;
-  min-height: 100%;
   padding: 3em 0 0 4em;
 
   overflow-y: auto;
@@ -185,6 +184,6 @@
 
 .container {
   .tocify-wrapper {
-    top: 240px;
+    top: 125px;
   }
 }

--- a/src/assets/stylesheets/_variables.scss
+++ b/src/assets/stylesheets/_variables.scss
@@ -69,7 +69,7 @@ $nav-width-tablet: 320px;
 $examples-width: 50%; // portion of the screen taken up by code examples
 $logo-margin: 20px; // margin between nav items and logo, ignored if search is active
 $header-padding: 4em;
-$header-height: 125px;
+$header-height: 126px;
 $main-padding: 28px; // padding to left and right of content & examples
 $nav-padding: 15px; // padding to left and right of navbar
 $nav-v-padding: 10px; // padding used vertically around search boxes and results

--- a/src/assets/stylesheets/_variables.scss
+++ b/src/assets/stylesheets/_variables.scss
@@ -69,6 +69,7 @@ $nav-width-tablet: 320px;
 $examples-width: 50%; // portion of the screen taken up by code examples
 $logo-margin: 20px; // margin between nav items and logo, ignored if search is active
 $header-padding: 4em;
+$header-height: 125px;
 $main-padding: 28px; // padding to left and right of content & examples
 $nav-padding: 15px; // padding to left and right of navbar
 $nav-v-padding: 10px; // padding used vertically around search boxes and results

--- a/src/assets/stylesheets/_variables.scss
+++ b/src/assets/stylesheets/_variables.scss
@@ -70,6 +70,7 @@ $examples-width: 50%; // portion of the screen taken up by code examples
 $logo-margin: 20px; // margin between nav items and logo, ignored if search is active
 $header-padding: 4em;
 $header-height: 126px;
+$header-height-phone: 63px;
 $main-padding: 28px; // padding to left and right of content & examples
 $nav-padding: 15px; // padding to left and right of navbar
 $nav-v-padding: 10px; // padding used vertically around search boxes and results

--- a/src/assets/stylesheets/_variables.scss
+++ b/src/assets/stylesheets/_variables.scss
@@ -70,7 +70,7 @@ $examples-width: 50%; // portion of the screen taken up by code examples
 $logo-margin: 20px; // margin between nav items and logo, ignored if search is active
 $header-padding: 4em;
 $header-height: 126px;
-$header-height-phone: 63px;
+$header-height-phone: 50px;
 $main-padding: 28px; // padding to left and right of content & examples
 $nav-padding: 15px; // padding to left and right of navbar
 $nav-v-padding: 10px; // padding used vertically around search boxes and results

--- a/src/assets/stylesheets/side-code/screen.scss
+++ b/src/assets/stylesheets/side-code/screen.scss
@@ -97,7 +97,7 @@
 
         > table {
           margin: 25px;
-          
+
           @media (max-width: $desktop-width) {
             margin: 25px 0;
           }
@@ -142,7 +142,7 @@
 @media (max-width: $large-desktop-width) {
   .container {
     .page-wrapper {
-      padding: 10px 0 55px 0;
+      padding: $header-height 0 55px 0;
     }
   }
 }
@@ -177,4 +177,13 @@
 
 @media (max-width: $desktop-width) {
 
+}
+
+//phone
+@media (max-width: $phone-width) {
+  .container {
+    .page-wrapper {
+      padding-top: $header-height-phone;
+    }
+  }
 }


### PR DESCRIPTION
Fix a styling bug spotted by @scottinet:
After the merge of UX restiling ( https://github.com/kuzzleio/documentation/pull/379 ), the default scroll for left menu had been broken: in pages with a very long left menu (example: http://docs.kuzzle.io/api-documentation/controller-memory-storage/georadius/ ), we did not scroll anymore the menu to the current page title.

This PR fixes that.

Also some tiny improvements with responsive styles and main content scrolling (now, the top header is fixed while scrolling).

Changes can be previewed here: https://janitor-saving-64803.netlify.com/