### PR TITLE
Document refresh option in Security

### DIFF
--- a/src/api-documentation/controller-security/create-or-replace-profile.md
+++ b/src/api-documentation/controller-security/create-or-replace-profile.md
@@ -16,7 +16,7 @@ title: createOrReplaceProfile
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/profiles/<profileId>`
+**URL:** `http://kuzzle:7512/profiles/<profileId>[?refresh=wait_for]`
 **Method:** `PUT`
 **Body**
 </p>
@@ -59,6 +59,7 @@ title: createOrReplaceProfile
 {
   "controller": "security",
   "action": "createOrReplaceProfile",
+  "refresh": "wait_for",
   "_id": "<profileId>",              
 
   "body": {
@@ -110,3 +111,6 @@ title: createOrReplaceProfile
 ```
 
 Creates or replaces (if `_id` matches an existing one) a profile with a list of policies.
+
+The optional parameter `refresh` can be used
+with the value `wait_for` in order to wait for the profile indexation (indexed profiles are available for `search`).

--- a/src/api-documentation/controller-security/create-or-replace-role.md
+++ b/src/api-documentation/controller-security/create-or-replace-role.md
@@ -16,7 +16,7 @@ title: createOrReplaceRole
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/roles/<roleId>`  
+**URL:** `http://kuzzle:7512/roles/<roleId>[?refresh=wait_for]`  
 **Method:** `PUT`  
 **Body**
 </p>
@@ -44,6 +44,7 @@ title: createOrReplaceRole
 {
   "controller": "security",
   "action": "createOrReplaceRole",
+  "refresh": "wait_for",
   "_id": "<roleId>",
 
   "body": {
@@ -88,6 +89,9 @@ title: createOrReplaceRole
 ```
 
 Validates and stores a role in Kuzzle's persistent data storage.
+
+The optional parameter `refresh` can be used
+with the value `wait_for` in order to wait for the role indexation (indexed roles are available for `search`).
 
 The body content needs to match Kuzzle's role definition.
 

--- a/src/api-documentation/controller-security/create-profile.md
+++ b/src/api-documentation/controller-security/create-profile.md
@@ -16,7 +16,7 @@ title: createProfile
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/profiles/<profileId>/_create`  
+**URL:** `http://kuzzle:7512/profiles/<profileId>/_create[?refresh=wait_for]`  
 **Method:** `POST`  
 **Body**
 </p>
@@ -59,6 +59,7 @@ title: createProfile
 {
   "controller": "security",
   "action": "createProfile",
+  "refresh": "wait_for",
   "_id": "<profileId>",
 
   "body": {
@@ -108,5 +109,8 @@ title: createProfile
 ```
 
 Creates a profile with a new list of roles.
+
+The optional parameter `refresh` can be used
+with the value `wait_for` in order to wait for the profile indexation (indexed profiles are available for `search`).
 
 **Note:** The `_id` parameter is mandatory.

--- a/src/api-documentation/controller-security/create-restricted-user.md
+++ b/src/api-documentation/controller-security/create-restricted-user.md
@@ -15,7 +15,7 @@ title: createRestrictedUser
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/users/<kuid>/_createRestricted` or `http://kuzzle:7512/users/_createRestricted`  
+**URL:** `http://kuzzle:7512/users/<kuid>/_createRestricted[?refresh=wait_for]` or `http://kuzzle:7512/users/_createRestricted[?refresh=wait_for]`  
 **Method:** `POST`  
 **Body**
 </p>
@@ -56,15 +56,15 @@ title: createRestrictedUser
 </p>
 </blockquote>
 
-```js
+```json
 {
   "controller": "security",
   "action": "createRestrictedUser",
+  "refresh": "wait_for",
   "_id": "<kuid>",
   "body": {
     "content": {
-      "name": "John Doe",                     // Additional optional User properties
-      ...
+      "name": "John Doe"
     },
     "credentials": {
       "strategy-name": {
@@ -72,22 +72,22 @@ title: createRestrictedUser
     }
   }
 }
+```
 
-// example with the "local" authentication strategy
-
+```json
 {
   "controller": "security",
   "action": "createRestrictedUser",
+  "refresh": "wait_for",
   "_id": "<kuid>",
   "body": {
     "content": {
-      "name": "John Doe",                     // Additional optional User properties
-      ...
+      "name": "John Doe"
     },
     "credentials": {
       "local": {
-        "username": "MyUser"                  // ie: Mandatory for "local" authentication plugin
-        "password": "MyPassword"              // ie: Mandatory for "local" authentication plugin
+        "username": "MyUser",
+        "password": "MyPassword"
       }
     }
   }

--- a/src/api-documentation/controller-security/create-role.md
+++ b/src/api-documentation/controller-security/create-role.md
@@ -16,7 +16,7 @@ title: createRole
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/roles/<roleId>/_create`  
+**URL:** `http://kuzzle:7512/roles/<roleId>/_create[?refresh=wait_for]`  
 **Method:** `POST`  
 **Body**
 </p>
@@ -44,6 +44,7 @@ title: createRole
 {
   "controller": "security",
   "action": "createRole",
+  "refresh": "wait_for",
   "_id": "<roleId>",
 
   "body": {
@@ -89,6 +90,9 @@ title: createRole
 
 Validates and stores a role in Kuzzle's persistent data storage.
 **Note:** The `_id` parameter is mandatory.
+
+The optional parameter `refresh` can be used
+with the value `wait_for` in order to wait for the role indexation (indexed roles are available for `search`).
 
 The body content needs to match Kuzzle's role definition.
 

--- a/src/api-documentation/controller-security/create-user.md
+++ b/src/api-documentation/controller-security/create-user.md
@@ -15,7 +15,7 @@ title: createUser
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/users/<kuid>/_create` or `http://kuzzle:7512/users/_create`  
+**URL:** `http://kuzzle:7512/users/<kuid>/_create[?refresh=wait_for]` or `http://kuzzle:7512/users/_create[?refresh=wait_for]`  
 **Method:** `POST`  
 **Body**
 </p>
@@ -62,7 +62,8 @@ title: createUser
 {
   "controller": "security",
   "action": "createUser",
-  "_id": "<kuid>",      
+  "refresh": "wait_for",
+  "_id": "<kuid>",
   "body": {
     "content": {
       "profileIds": ["<profileId>"],    
@@ -80,7 +81,8 @@ title: createUser
 {
   "controller": "security",
   "action": "createUser",
-  "_id": "<kuid>",                      
+  "refresh": "wait_for",
+  "_id": "<kuid>",
   "body": {
     "content": {
       "profileIds": ["<profileId>"],    
@@ -127,6 +129,9 @@ Creates a new `user` in Kuzzle's database layer.
 
 If an `_id` is provided in the query and if a user [`<kuid>`]({{ site_base_path }}guide/essentials/user-authentication/#kuzzle-user-identifier-kuid) already exists, an error is returned.
 If not provided, the `_id` will be auto-generated.
+
+The optional parameter `refresh` can be used
+with the value `wait_for` in order to wait for the user indexation (indexed users are available for `search`).
 
 The body content describes the user to be created, and it must have the following properties:
 

--- a/src/api-documentation/controller-security/delete-profile.md
+++ b/src/api-documentation/controller-security/delete-profile.md
@@ -16,7 +16,7 @@ title: deleteProfile
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/_profiles/<profileId>`  
+**URL:** `http://kuzzle:7512/_profiles/<profileId>[?refresh=wait_for]`  
 **Method:** `DELETE`
 </p>
 </blockquote>
@@ -31,6 +31,7 @@ title: deleteProfile
 {
   "controller": "security",
   "action": "deleteProfile",
+  "refresh": "wait_for",
 
   "_id": "<profileId>"
 }
@@ -55,6 +56,9 @@ title: deleteProfile
 
 Given a `profile id`, deletes the corresponding profile from the database. Note
 that the related roles will NOT be deleted.
+
+The optional parameter `refresh` can be used
+with the value `wait_for` in order to wait for the profile's deletion indexation (indexed profiles are available for `search`).
 
 <aside class="notice">
 The profile unique identifier. It's the same you set when you create a profile.

--- a/src/api-documentation/controller-security/delete-role.md
+++ b/src/api-documentation/controller-security/delete-role.md
@@ -16,7 +16,7 @@ title: deleteRole
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/roles/<roleId>`  
+**URL:** `http://kuzzle:7512/roles/<roleId>[?refresh=wait_for]`  
 **Method:** `DELETE`
 </p>
 </blockquote>
@@ -31,6 +31,7 @@ title: deleteRole
 {
   "controller": "security",
   "action": "deleteRole",
+  "refresh": "wait_for",
 
   "_id": "<roleId>"
 }
@@ -55,6 +56,8 @@ title: deleteRole
 
 Given a `role id`, deletes the corresponding role from the database.
 
+The optional parameter `refresh` can be used
+with the value `wait_for` in order to wait for the role's deletion indexation (indexed roles are available for `search`).
 
 <aside class="notice">
 The role unique identifier. It's the same you set when you create a role.

--- a/src/api-documentation/controller-security/delete-user.md
+++ b/src/api-documentation/controller-security/delete-user.md
@@ -16,7 +16,7 @@ title: deleteUser
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/users/<kuid>`  
+**URL:** `http://kuzzle:7512/users/<kuid>[?refresh=wait_for]`  
 **Method:** `DELETE`
 </p>
 </blockquote>
@@ -31,6 +31,7 @@ title: deleteUser
 {
   "controller": "security",
   "action": "deleteUser",
+  "refresh": "wait_for",
 
   "_id": "<kuid>"
 }
@@ -54,3 +55,6 @@ title: deleteUser
 ```
 
 Given a `user id`, deletes the corresponding [`<kuid>`]({{ site_base_path }}guide/essentials/user-authentication/#kuzzle-user-identifier-kuid) from Kuzzle's database layer.
+
+The optional parameter `refresh` can be used
+with the value `wait_for` in order to wait for the user's deletion indexation (indexed users are available for `search`).

--- a/src/api-documentation/controller-security/m-delete-profiles.md
+++ b/src/api-documentation/controller-security/m-delete-profiles.md
@@ -16,7 +16,7 @@ title: mDeleteProfiles
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/profiles/_mDelete`  
+**URL:** `http://kuzzle:7512/profiles/_mDelete[?refresh=wait_for]`  
 **Method:** `POST`  
 **Body:**
 </p>
@@ -40,6 +40,7 @@ title: mDeleteProfiles
 {
   "controller": "security",
   "action": "mDeleteProfiles",
+  "refresh": "wait_for",
   "body": {
     "ids": ["myFirstProfile", "mySecondProfile"]
   }
@@ -63,3 +64,6 @@ title: mDeleteProfiles
 ```
 
 Deletes a list of `profile` objects from Kuzzle's database layer given a list of profile ids.
+
+The optional parameter `refresh` can be used
+with the value `wait_for` in order to wait for the profiles' deletion indexation (indexed profiles are available for `search`).

--- a/src/api-documentation/controller-security/m-delete-roles.md
+++ b/src/api-documentation/controller-security/m-delete-roles.md
@@ -16,7 +16,7 @@ title: mDeleteRoles
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/roles/_mDelete`  
+**URL:** `http://kuzzle:7512/roles/_mDelete[?refresh=wait_for]`  
 **Method:** `POST`  
 **Body:**
 </p>
@@ -40,6 +40,7 @@ title: mDeleteRoles
 {
   "controller": "security",
   "action": "mDeleteRoles",
+  "refresh": "wait_for",
   "body": {
     "ids": ["myFirstRole", "mySecondRole"]
   }
@@ -63,3 +64,6 @@ title: mDeleteRoles
 ```
 
 Deletes a list of `roles` objects from Kuzzle's database layer given a list of role ids.
+
+The optional parameter `refresh` can be used
+with the value `wait_for` in order to wait for the roles' deletion indexation (indexed roles are available for `search`).

--- a/src/api-documentation/controller-security/m-delete-users.md
+++ b/src/api-documentation/controller-security/m-delete-users.md
@@ -16,7 +16,7 @@ title: mDeleteUsers
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/users/_mDelete`  
+**URL:** `http://kuzzle:7512/users/_mDelete[?refresh=wait_for]`  
 **Method:** `POST`  
 **Body:**
 </p>
@@ -40,6 +40,7 @@ title: mDeleteUsers
 {
   "controller": "security",
   "action": "mDeleteUsers",
+  "refresh": "wait_for",
   "body": {
     "ids": ["firstKuid", "secondKuid"]
   }
@@ -64,3 +65,6 @@ title: mDeleteUsers
 ```
 
 Deletes a list of `users` objects from Kuzzle's database layer given a list of [`<kuids>`]({{ site_base_path }}guide/essentials/user-authentication/#kuzzle-user-identifier-kuid).
+
+The optional parameter `refresh` can be used
+with the value `wait_for` in order to wait for the users' deletion indexation (indexed users are available for `search`).

--- a/src/api-documentation/controller-security/replace-user.md
+++ b/src/api-documentation/controller-security/replace-user.md
@@ -13,7 +13,7 @@ title: replaceUser
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/users/<kuid>/_replace`  
+**URL:** `http://kuzzle:7512/users/<kuid>/_replace[?refresh=wait_for]`  
 **Method:** `PUT`  
 **Body**
 </p>
@@ -37,6 +37,7 @@ title: replaceUser
 {
   "controller": "security",
   "action": "replaceUser",
+  "refresh": "wait_for",
   "_id": "<kuid>",
   "body": {
     "profileIds": ["<profileId>"],
@@ -67,3 +68,6 @@ title: replaceUser
 ```
 
 Given a [`<kuid>`]({{ site_base_path }}guide/essentials/user-authentication/#kuzzle-user-identifier-kuid), replaces the matching User object in Kuzzle's database layer.
+
+The optional parameter `refresh` can be used
+with the value `wait_for` in order to wait for the user indexation (indexed users are available for `search`).

--- a/src/api-documentation/controller-security/update-profile.md
+++ b/src/api-documentation/controller-security/update-profile.md
@@ -16,7 +16,7 @@ title: updateProfile
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/profiles/<profileId>/_update`  
+**URL:** `http://kuzzle:7512/profiles/<profileId>/_update[?refresh=wait_for]`  
 **Method:** `PUT`  
 **Body**
 </p>
@@ -58,6 +58,7 @@ title: updateProfile
 {
   "controller": "security",
   "action": "updateProfile",
+  "refresh": "wait_for",
   "_id": "<profileId>",
   "body": {
     "policies": [
@@ -105,3 +106,6 @@ title: updateProfile
 ```
 
 Given a `profileId`, updates the matching Profile object in Kuzzle's database layer.
+
+The optional parameter `refresh` can be used
+with the value `wait_for` in order to wait for the profile indexation (indexed profiles are available for `search`).

--- a/src/api-documentation/controller-security/update-role.md
+++ b/src/api-documentation/controller-security/update-role.md
@@ -16,7 +16,7 @@ title: updateRole
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/roles/<roleId>/_update`  
+**URL:** `http://kuzzle:7512/roles/<roleId>/_update[?refresh=wait_for]`  
 **Method:** `PUT`  
 **Body**
 </p>
@@ -44,6 +44,7 @@ title: updateRole
 {
   "controller": "security",
   "action": "updateRole",
+  "refresh": "wait_for",
   "_id": "<roleId>",
   "body": {
     "controllers": {
@@ -78,6 +79,9 @@ title: updateRole
 ```
 
 Given a `role id`, updates the matching Role object in Kuzzle's database layer.
+
+The optional parameter `refresh` can be used
+with the value `wait_for` in order to wait for the role indexation (indexed roles are available for `search`).
 
 The body content needs to match Kuzzle's role definition.
 

--- a/src/api-documentation/controller-security/update-user.md
+++ b/src/api-documentation/controller-security/update-user.md
@@ -16,7 +16,7 @@ title: updateUser
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/users/<kuid>/_update`  
+**URL:** `http://kuzzle:7512/users/<kuid>/_update[?refresh=wait_for]`  
 **Method:** `PUT`  
 **Body**
 </p>
@@ -40,6 +40,7 @@ title: updateUser
 {
   "controller": "security",
   "action": "updateUser",
+  "refresh": "wait_for",
   "_id": "<kuid>",
   "body": {
     "foo": "bar",    
@@ -69,3 +70,6 @@ title: updateUser
 ```
 
 Given a [`<kuid>`]({{ site_base_path }}guide/essentials/user-authentication/#kuzzle-user-identifier-kuid), updates the matching User object in Kuzzle's database layer.
+
+The optional parameter `refresh` can be used
+with the value `wait_for` in order to wait for the user indexation (indexed users are available for `search`).

--- a/src/sdk-reference/security/create-profile.md
+++ b/src/sdk-reference/security/create-profile.md
@@ -130,8 +130,9 @@ That means that a profile that was just been created will not be returned by <co
 
 | Filter | Type | Description | Default |
 |---------------|---------|----------------------------------------|---------|
-| ``replaceIfExist`` | boolean | If the same profile already exists: throw an error if sets to false. Replace the existing profile otherwise | ``false`` |
 | ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
+| ``replaceIfExist`` | boolean | If the same profile already exists: throw an error if sets to false. Replace the existing profile otherwise | ``false`` |
+| ``refresh`` | string | If set to ``wait_for``, Kuzzle will wait the persistence layer indexation to return (available with Elasticsearch 5.x and above) | ``undefined`` |
 
 ---
 

--- a/src/sdk-reference/security/create-restricted-user.md
+++ b/src/sdk-reference/security/create-restricted-user.md
@@ -128,6 +128,7 @@ That means that a user that was just been created will not be returned by <code>
 | Filter | Type | Description | Default |
 |---------------|---------|----------------------------------------|---------|
 | ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
+| ``refresh`` | string | If set to ``wait_for``, Kuzzle will wait the persistence layer indexation to return (available with Elasticsearch 5.x and above) | ``undefined`` |
 
 ---
 

--- a/src/sdk-reference/security/create-role.md
+++ b/src/sdk-reference/security/create-role.md
@@ -127,6 +127,7 @@ That means that a role that was just been created will not be returned by <code>
 |---------------|---------|----------------------------------------|---------|
 | ``replaceIfExist`` | boolean | If the same role already exists: throw an error if sets to false. Replace the existing role otherwise | ``false`` |
 | ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
+| ``refresh`` | string | If set to ``wait_for``, Kuzzle will wait the persistence layer indexation to return (available with Elasticsearch 5.x and above) | ``undefined`` |
 
 ---
 

--- a/src/sdk-reference/security/create-user.md
+++ b/src/sdk-reference/security/create-user.md
@@ -146,6 +146,7 @@ That means that a user that was just been created will not be returned by <code>
 | ``user`` | JSON Object | A plain JSON object representing the user (see below) |
 | ``options`` | string | (Optional) Optional arguments |
 | ``callback`` | function | Callback handling the response |
+| ``refresh`` | string | If set to ``wait_for``, Kuzzle will wait the persistence layer indexation to return (available with Elasticsearch 5.x and above) | ``undefined`` |
 
 
 The `user` object to provide must have the following properties:

--- a/src/sdk-reference/security/delete-profile.md
+++ b/src/sdk-reference/security/delete-profile.md
@@ -90,6 +90,7 @@ That means that a profile that was just been delete will be returned by <code>se
 | Option | Type | Description | Default |
 |---------------|---------|----------------------------------------|---------|
 | ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
+| ``refresh`` | string | If set to ``wait_for``, Kuzzle will wait the persistence layer indexation to return (available with Elasticsearch 5.x and above) | ``undefined`` |
 
 
 ---

--- a/src/sdk-reference/security/delete-role.md
+++ b/src/sdk-reference/security/delete-role.md
@@ -90,6 +90,7 @@ That means that a role that was just been delete will be returned by <code>searc
 | Option | Type | Description | Default |
 |---------------|---------|----------------------------------------|---------|
 | ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
+| ``refresh`` | string | If set to ``wait_for``, Kuzzle will wait the persistence layer indexation to return (available with Elasticsearch 5.x and above) | ``undefined`` |
 
 ---
 

--- a/src/sdk-reference/security/delete-user.md
+++ b/src/sdk-reference/security/delete-user.md
@@ -90,6 +90,7 @@ That means that a user that has just been delete will be returned by <code>searc
 | Option | Type | Description | Default |
 |---------------|---------|----------------------------------------|---------|
 | ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
+| ``refresh`` | string | If set to ``wait_for``, Kuzzle will wait the persistence layer indexation to return (available with Elasticsearch 5.x and above) | ``undefined`` |
 
 ---
 

--- a/src/sdk-reference/security/replace-user.md
+++ b/src/sdk-reference/security/replace-user.md
@@ -95,6 +95,7 @@ Replaces an existing user.
 | Filter | Type | Description | Default |
 |---------------|---------|----------------------------------------|---------|
 | ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
+| ``refresh`` | string | If set to ``wait_for``, Kuzzle will wait the persistence layer indexation to return (available with Elasticsearch 5.x and above) | ``undefined`` |
 
 ---
 

--- a/src/sdk-reference/security/update-profile.md
+++ b/src/sdk-reference/security/update-profile.md
@@ -119,6 +119,7 @@ Performs a partial update on an existing profile.
 | Filter | Type | Description | Default |
 |---------------|---------|----------------------------------------|---------|
 | ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
+| ``refresh`` | string | If set to ``wait_for``, Kuzzle will wait the persistence layer indexation to return (available with Elasticsearch 5.x and above) | ``undefined`` |
 
 ---
 

--- a/src/sdk-reference/security/update-role.md
+++ b/src/sdk-reference/security/update-role.md
@@ -113,6 +113,7 @@ Performs a partial update on an existing role.
 | Filter | Type | Description | Default |
 |---------------|---------|----------------------------------------|---------|
 | ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
+| ``refresh`` | string | If set to ``wait_for``, Kuzzle will wait the persistence layer indexation to return (available with Elasticsearch 5.x and above) | ``undefined`` |
 
 ---
 

--- a/src/sdk-reference/security/update-user.md
+++ b/src/sdk-reference/security/update-user.md
@@ -98,6 +98,7 @@ Performs a partial update on an existing user.
 | Filter | Type | Description | Default |
 |---------------|---------|----------------------------------------|---------|
 | ``queuable`` | boolean | Mark this request as (not) queuable | ``true`` |
+| ``refresh`` | string | If set to ``wait_for``, Kuzzle will wait the persistence layer indexation to return (available with Elasticsearch 5.x and above) | ``undefined`` |
 
 ---
 


### PR DESCRIPTION
The refresh option is now available in the security controller.
Documents the option in both API and SDK documentations.

fixes #392