### PR TITLE
fix SearchResult API documentation

### DIFF
--- a/src/sdk-reference/search-result/index.md
+++ b/src/sdk-reference/search-result/index.md
@@ -13,34 +13,7 @@ subheader-title: Constructor
 
 # Constructor
 
-```js
-/* 
- This class can only be instantiated internally by this SDK, 
- either as a result of a document search API call, a result
- of a scroll API call, or by requesting the next result page
- using this class "fetchNext" exposed method
- */
-```
-
-```java
-/* 
- This class can only be instantiated internally by this SDK, 
- either as a result of a document search API call, a result
- of a scroll API call, or by requesting the next result page
- using this class "fetchNext" exposed method
- */
-```
-
-```php
-/* 
- This class can only be instantiated internally by this SDK, 
- either as a result of a document search API call, a result
- of a scroll API call, or by requesting the next result page
- using this class "fetchNext" exposed method
- */
-```
-
-This object is the result of a [search]({{ site_base_path }}sdk-reference/collection/search) or a [scroll]({{ site_base_path }}sdk-reference/collection/scroll) request, allowing to manipulate the result and do subsequent requests.
+This object can only be instantiated internally by this SDK, and is an easy-to-use representation of a paginated result from a [search]({{ site_base_path }}sdk-reference/collection/search) or a [scroll]({{ site_base_path }}sdk-reference/collection/scroll) request.
 
 ---
 

--- a/src/sdk-reference/search-result/index.md
+++ b/src/sdk-reference/search-result/index.md
@@ -14,86 +14,33 @@ subheader-title: Constructor
 # Constructor
 
 ```js
-/*
- Constructors are not exposed in the JS/Node SDK.
- SearchResult objects are returned by search and scroll Collection methods.
+/* 
+ This class can only be instantiated internally by this SDK, 
+ either as a result of a document search API call, a result
+ of a scroll API call, or by requesting the next result page
+ using this class "fetchNext" exposed method
  */
-
-kuzzle.collection('collection', 'index').search({}, (error, searchResult) => {
-  // searchResult is a SearchResult object
-});
 ```
 
 ```java
-JSONObject filter = new JSONObject();
-
-kuzzle
-  .collection("collection", "index")
-  .search(filter, new ResponseListener<SearchResult>() {
-    @Override
-    public void onSuccess(SearchResult searchResult) {
-      for (Document doc : result.getDocuments()) {
-        // fetched documents
-      }
-
-      result.getTotal(); // returns the total number of documents returnable
-
-      result.getAggregations(): // returns a JSONObject representing the aggregations response
-    }
-
-    @Override
-    public void onError(JSONObject error) {
-      // Handle error
-    }
-  });
+/* 
+ This class can only be instantiated internally by this SDK, 
+ either as a result of a document search API call, a result
+ of a scroll API call, or by requesting the next result page
+ using this class "fetchNext" exposed method
+ */
 ```
 
 ```php
-<?php
-
-use \Kuzzle\Kuzzle;
-
-
-$filters = (object) [];
-
-$kuzzle = new Kuzzle('localhost');
-$dataCollection = $kuzzle->collection('collection', 'index');
-
-try {
-  $searchResult = $dataCollection->search($filters);
-
-  // $searchResult instanceof SearchResult
-  $searchResult->getTotal();
-
-  foreach($searchResult->getDocuments() as $document) {
-    // $document instanceof Document
-  }
-
-  // return an array representing the aggregations response
-  $searchResult->getAggregations();
-}
-catch (ErrorException $e) {
-
-}
+/* 
+ This class can only be instantiated internally by this SDK, 
+ either as a result of a document search API call, a result
+ of a scroll API call, or by requesting the next result page
+ using this class "fetchNext" exposed method
+ */
 ```
 
 This object is the result of a [search]({{ site_base_path }}sdk-reference/collection/search) or a [scroll]({{ site_base_path }}sdk-reference/collection/scroll) request, allowing to manipulate the result and do subsequent requests.
-
----
-
-## SearchResult(collection, total, documents, aggregations, options, filters, [previous])
-
-| Arguments | Type | Description |
-|---------------|---------|----------------------------------------|
-| ``collection`` | Collection | An instantiated [Collection]({{ site_base_path }}sdk-reference/collection) object |
-| ``total`` | integer | The total number of results of the search/scroll request |
-| ``documents`` | Document[] | An array of instantiated [Document]({{ site_base_path }}sdk-reference/document) objects |
-| ``aggregations`` | object | The result of an aggregation produced by a search request |
-| ``options`` | object | The arguments of the search/scroll request |
-| ``filters`` | object | The filters of the search request |
-| ``previous`` | SearchRequest | The previous SearchResult produced by a previous search/scroll request (see [fetchNext]({{ site_base_path }}sdk-reference/search-result/fetch-next)) |
-
-**Note:** this constructor is meant to be called internally when retrieving results from a search or a scroll request.
 
 ---
 
@@ -104,21 +51,9 @@ This object is the result of a [search]({{ site_base_path }}sdk-reference/collec
 | ``aggregations`` | object | The result of an aggregation produced by a search request | get |
 | ``collection`` | Collection | The data collection associated to this document | get |
 | ``documents`` | Document[] | An array of instantiated Document objects | get |
-| ``fetchedDocument`` | number | Represents the offset of the last document in the current SearchResult set | get/set |
+| ``fetched`` | number | The number of fetched documents so far | get/set |
 | ``options`` | object | The arguments of the search/scroll request | get |
 | ``filters`` | object | The filters of the search request | get |
-| ``total`` | integer | The total number of results of the search/scroll request | get |
+| ``total`` | integer | The total number of results that can be fetched | get |
 
 ---
-
-## Getters
-
-| Getter name | Type | Description |
-|-------------|------|--------------------------------------------|
-| ``getAggregations()`` | object | Returns the `aggregation` property value |
-| ``getCollection()`` | Collection | Returns the `collection` property value |
-| ``getDocuments()`` | Document[] | Returns the `documents` property value |
-| ``getFetchedDocument()`` | number | Returns the `fetchedDocument` property value |
-| ``getOptions()`` | object | Returns the `options` property value |
-| ``getFilters()`` | object | Returns the `filters` property value |
-| ``getTotal()`` | integer | Returns the `total` property value |


### PR DESCRIPTION
* remove the SearchResult API constructor documentation: this class is meant to be built internally by SDKs to provide a clean search result API, and there is no point for users to instantiate it
* remove SearchResult API getters documentation: property getters are implementation details depending on a language, and therefore should not be documented in the SDK specifications
* the `fetchedDocument` property is renamed `fetched` and its documentation has been updated to make it clearer that it represents the number of documents fetched so far by the paginated search API