### PR TITLE
Add documentation for signal handling

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -43,3 +43,5 @@
   Describe here minor improvements in the code base and not directly linked to the main changes:
   typos fixes, better/new comments, small code simplification, new debug messages, and so on.
 -->
+
+### Screenshots (if appropriate)

--- a/src/guide/essentials/plugins.md
+++ b/src/guide/essentials/plugins.md
@@ -2,7 +2,7 @@
 layout: full.html
 algolia: true
 title: Kuzzle's Plugin Engine
-order: 1000
+order: 1100
 ---
 
 # Kuzzle's Plugin Engine
@@ -174,7 +174,7 @@ To learn more about how to manage or configure plugins, please check our [Plugin
 To get more insight into how plugins work, please refer to the [Plugin Reference]({{ site_base_path }}plugins-reference).
 
 Here is a list of official plugins:
-- [**kuzzle-plugin-auth-passport-local**](https://github.com/kuzzleio/kuzzle-plugin-auth-passport-local): authentication Plugin shipped with Kuzzle 
+- [**kuzzle-plugin-auth-passport-local**](https://github.com/kuzzleio/kuzzle-plugin-auth-passport-local): authentication Plugin shipped with Kuzzle
 - [**kuzzle-plugin-logger**](https://github.com/kuzzleio/kuzzle-plugin-logger): worker Plugin shipped with Kuzzle
 - [**kuzzle-plugin-auth-passport-oauth**](https://github.com/kuzzleio/kuzzle-plugin-auth-passport-oauth): authentication plugin
 - [**kuzzle-plugin-mqtt**](https://github.com/kuzzleio/kuzzle-plugin-mqtt): protocol plugin

--- a/src/guide/essentials/signal_handling.md
+++ b/src/guide/essentials/signal_handling.md
@@ -7,7 +7,7 @@ order: 1000
 
 # Signal Handling
 
-Kuzzle caught some Unix signals, they are distributed in 3 categories :
+Kuzzle handles certain Unix signals which fall into the following three categories:
 
  * Abnormal termination
  * Normal termination
@@ -17,26 +17,26 @@ The code related to signal handling can be seen here : [lib/api/kuzzle.js#L183](
 
 ## Abnormal termination
 
-Concerned signals :
+Unix signal names:
  * `SIGQUIT`
  * `SIGABRT`
  * `SIGPIPE`
 
-These signals represents a critical error and will force Kuzzle to quit.  
-When one of the signal above is caught, Kuzzle will first generate a [dump report]({{ site_base_path }}guide/essentials/cli#dump) and then quit directly.  
+ These signals are the result of a critical error and will force Kuzzle to shutdown.
+ When one of the aforementioned Unix signals is detected, Kuzzle will first generate a [dump report]({{ site_base_path }}guide/essentials/cli#dump) and then shutdown.
 
 ## Normal termination  
 
-Concerned signals :
+Unix signal names:
  * `SIGTERM`
  * `SIGINT`
 
-These signals represents a willingness to quit Kuzzle gracefully.  
-Once one of the signal above is caught, Kuzzle will refuse new requests, exit the cluster, finish the current request queue and then quit.  
+ These signals are the result of a request to terminate gracefully.
+ When one of the aforementioned Unix signals is detected, Kuzzle will refuse new requests, exit the cluster, finish the current request queue and then shutdown.
 
 ## Dump report
 
-Concerned signals :
+Unix signal names:
  * `SIGTRAP`
 
-These signals are used to generate a [dump report]({{ site_base_path }}guide/essentials/cli#dump). Once caught, Kuzzle will generate a dump report and continue to serve requests normally.
+When one of the aforementioned Unix signals is detected, Kuzzle will generate a dump report and continue to serve requests normally.

--- a/src/guide/essentials/signal_handling.md
+++ b/src/guide/essentials/signal_handling.md
@@ -1,0 +1,42 @@
+---
+layout: full.html
+algolia: true
+title: Signal Handling
+order: 1000
+---
+
+# Signal Handling
+
+Kuzzle caught some Unix signals, they are distributed in 3 categories :
+
+ * Abnormal termination
+ * Normal termination
+ * Dump report generation
+
+The code related to signal handling can be seen here : [lib/api/kuzzle.js#L183](https://github.com/kuzzleio/kuzzle/blob/master/lib/api/kuzzle.js#L183)
+
+## Abnormal termination
+
+Concerned signals :
+ * `SIGQUIT`
+ * `SIGABRT`
+ * `SIGPIPE`
+
+These signals represents a critical error and will force Kuzzle to quit.  
+When one of the signal above is caught, Kuzzle will first generate a [dump report]({{ site_base_path }}guide/essentials/cli#dump) and then quit directly.  
+
+## Normal termination  
+
+Concerned signals :
+ * `SIGTERM`
+ * `SIGINT`
+
+These signals represents a willingness to quit Kuzzle gracefully.  
+Once one of the signal above is caught, Kuzzle will refuse new requests, exit the cluster, finish the current request queue and then quit.  
+
+## Dump report
+
+Concerned signals :
+ * `SIGTRAP`
+
+These signals are used to generate a [dump report]({{ site_base_path }}guide/essentials/cli#dump). Once caught, Kuzzle will generate a dump report and continue to serve requests normally.


### PR DESCRIPTION
## What does this PR do ?

This PR add documentation about the signal handling performed by Kuzzle.   
Kuzzle handle various signals for different actions and this should be documented.   
I added a new page in the Kuzzle - Essential section.  


Fix [backlog#244](https://github.com/kuzzleio/kuzzle-backlog/issues/244)

### How should this be manually tested?

  - Step 1 : Go to https://deploy-preview-475--hawker-sarah-11661.netlify.com
  - Step 2 : Click on `Essentials`
  - Step 3 :  Click on `Signal handling`

### Other changes

### Boyscout

 - Add screenshot section to pull request template

### Screenshot (if appropriate)

![image](https://user-images.githubusercontent.com/4447392/39115700-c8e3f8d8-46e2-11e8-83fd-af0b4f99225a.png)
