### PR TITLE
Fix document metadata guide

### DIFF
--- a/src/guide/essentials/document-metadata.md
+++ b/src/guide/essentials/document-metadata.md
@@ -51,7 +51,7 @@ Here is an example of a Kuzzle response, containing a document's `_id`, `_source
 Documents metadata is managed by Kuzzle and cannot be changed using the API.  
 Metadata is stored in the _kuzzle_info field of each document in Elasticsearch.
 
-Kuzzle is able to handle documents without metadata, either because they were inserted without using Kuzzle or before Kuzzle was used. In either case, metadata will be automatically be added when these documents are updated.
+Elasticsearch might contain documents that don't have metadata. This can be the case for documents that were not inserted through Kuzzle. Such documents will automatically obtain metadata when they are updated through Kuzzle.
 
 ---
 

--- a/src/guide/essentials/document-metadata.md
+++ b/src/guide/essentials/document-metadata.md
@@ -51,13 +51,13 @@ Here is an example of a Kuzzle response, containing a document's `_id`, `_source
 Documents metadata are managed by Kuzzle and cannot be changed using the API.  
 They are stored in Elasticsearch directly inside the document, under the `_kuzzle_info` sub-object.
 
-Kuzzle is able to handle documents without metadata, because they were inserted without using Kuzzle, or before Kuzzle was used. In this case, metadata will be automatically be added when these documents are updated.
+Kuzzle is able to handle documents without metadata, either because they were inserted without using Kuzzle or before Kuzzle was used. In either cases, metadata will be automatically be added when these documents are updated.
 
 ---
 
 ## Querying Metadata
 
-Kuzzle allows search requests to access metadata directly. This means that you'll have to search in the `_kuzzle_info` document property directly.
+Kuzzle allows search requests to access metadata directly. This means that you'll have to search in the `_kuzzle_info` document property.
 
 For example, to query by a document's creation timestamp, we can use the following search filter:
 

--- a/src/guide/essentials/document-metadata.md
+++ b/src/guide/essentials/document-metadata.md
@@ -22,7 +22,7 @@ Metadata can be viewed in the document's `_meta` field and contains the followin
 * `active`: The status of the document. `true` if the document is active and `false` if the document has been put in the trashcan.
 * `deletedAt`: Timestamp of document deletion in epoch-milliseconds format, or `null` if the document has not been deleted.
 
-Here is an example of a document and its `_meta` field:
+Here is an example of a Kuzzle response, containing a document's `_id`, `_source` and `_meta` fields:
 
 ```json
 {
@@ -46,15 +46,26 @@ Here is an example of a document and its `_meta` field:
 
 ---
 
+## How metadata are physically stored
+
+Documents metadata are managed by Kuzzle and cannot be changed using the API.  
+They are stored in Elasticsearch directly inside the document, under the `_kuzzle_info` sub-object.
+
+Kuzzle is able to handle documents without metadata, because they were inserted without using Kuzzle, or before Kuzzle was used. In this case, metadata will be automatically be added when these documents are updated.
+
+---
+
 ## Querying Metadata
 
-Metadata can be queried like any other document property. For example, to query by a document's creation timestamp, we can use the following search filter:
+Kuzzle allows search requests to access metadata directly. This means that you'll have to search in the `_kuzzle_info` document property directly.
+
+For example, to query by a document's creation timestamp, we can use the following search filter:
 
 ```json
 {
   "query": {
       "range": {
-          "_meta.createdAt": {
+          "_kuzzle_info.createdAt": {
             "lte": 1481816930000
           }
       }

--- a/src/guide/essentials/document-metadata.md
+++ b/src/guide/essentials/document-metadata.md
@@ -51,7 +51,7 @@ Here is an example of a Kuzzle response, containing a document's `_id`, `_source
 Documents metadata are managed by Kuzzle and cannot be changed using the API.  
 They are stored in Elasticsearch directly inside the document, under the `_kuzzle_info` sub-object.
 
-Kuzzle is able to handle documents without metadata, either because they were inserted without using Kuzzle or before Kuzzle was used. In either cases, metadata will be automatically be added when these documents are updated.
+Kuzzle is able to handle documents without metadata, either because they were inserted without using Kuzzle or before Kuzzle was used. In either case, metadata will be automatically be added when these documents are updated.
 
 ---
 

--- a/src/guide/essentials/document-metadata.md
+++ b/src/guide/essentials/document-metadata.md
@@ -48,8 +48,8 @@ Here is an example of a Kuzzle response, containing a document's `_id`, `_source
 
 ## How metadata are physically stored
 
-Documents metadata are managed by Kuzzle and cannot be changed using the API.  
-They are stored in Elasticsearch directly inside the document, under the `_kuzzle_info` sub-object.
+Documents metadata is managed by Kuzzle and cannot be changed using the API.  
+Metadata is stored in the _kuzzle_info field of each document in Elasticsearch.
 
 Kuzzle is able to handle documents without metadata, either because they were inserted without using Kuzzle or before Kuzzle was used. In either case, metadata will be automatically be added when these documents are updated.
 


### PR DESCRIPTION
## Description

The documentation erroneously stated that document metadata could be searched using the `_meta` document property, instead of the `_kuzzle_info` one.

### Other changes

Added some explanations on how metadata are stored in the database. This gives more control to users, and explains a bit why metadata must be searched through the `_kuzzle_info` property (even if, in a future version, I'd like for the metadata renaming to be removed)
