### PR TITLE
Add documentation for http events

### DIFF
--- a/src/kuzzle-events/http/index.md
+++ b/src/kuzzle-events/http/index.md
@@ -14,6 +14,66 @@ Events triggered on HTTP communications.
 
 ---
 
+### `http:get`
+
+**Event type:** Pipe
+
+**Payload:** a [Request]({{ site_base_path }}plugins-reference/plugins-context/constructors/#request) object
+
+Triggered whenever a request has been submitted through HTTP GET methods.
+
+---
+
+### `http:post`
+
+**Event type:** Pipe
+
+**Payload:** a [Request]({{ site_base_path }}plugins-reference/plugins-context/constructors/#request) object
+
+Triggered whenever a request has been submitted through HTTP POST methods.
+
+---
+
+### `http:put`
+
+**Event type:** Pipe
+
+**Payload:** a [Request]({{ site_base_path }}plugins-reference/plugins-context/constructors/#request) object
+
+Triggered whenever a request has been submitted through HTTP PUT methods.
+
+---
+
+### `http:patch`
+
+**Event type:** Pipe
+
+**Payload:** a [Request]({{ site_base_path }}plugins-reference/plugins-context/constructors/#request) object
+
+Triggered whenever a request has been submitted through HTTP PATCH methods.
+
+---
+
+### `http:delete`
+
+**Event type:** Pipe
+
+**Payload:** a [Request]({{ site_base_path }}plugins-reference/plugins-context/constructors/#request) object
+
+Triggered whenever a request has been submitted through HTTP DELETE methods.
+
+---
+
+### `http:head`
+
+**Event type:** Pipe
+
+**Payload:** a [Request]({{ site_base_path }}plugins-reference/plugins-context/constructors/#request) object
+
+Triggered whenever a request has been submitted through HTTP HEAD methods.
+
+---
+
 ### `http:options`
 
 **Event type:** Pipe

--- a/src/sdk-reference/kuzzle/get-my-rights.md
+++ b/src/sdk-reference/kuzzle/get-my-rights.md
@@ -13,14 +13,12 @@ title: getMyRights
 ```js
 // Using callbacks (NodeJS or Web Browser)
 kuzzle
-  .security
   .getMyRights(function(error, rights) {
     // result is an array of objects
   });
 
 // Using promises (NodeJS)
 kuzzle
-  .security
   .getMyRightsPromise()
   .then(rights => {
     // result is an array of objects


### PR DESCRIPTION
## What does this PR do ?

This PR add documentation about the HTTP events fired by the router.  
See https://github.com/kuzzleio/kuzzle/pull/1108 for more informations.  

### How should this be manually tested?

<!--
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->
  - Step 1 : Go to https://deploy-preview-478--kuzzle-documentation.netlify.com/kuzzle-events/http and check if all events are listed

### Boyscout

 - Fix https://github.com/kuzzleio/documentation/issues/477 : wrong location of `getMyRights()`
