### PR TITLE
Put a table of content in right side of pages

### DIFF
--- a/src/assets/javascript/ux-toc.js
+++ b/src/assets/javascript/ux-toc.js
@@ -1,25 +1,5 @@
 (function tocUX() {
   var $toc = $('.toc');
-  var $content = $('.content');
-
-  //----------------------------
-  // fixes toc next to content
-  if ($toc.length > 0) {
-    var debounceComputeSize = false;
-    var computeSize = function() {
-      // 280 is the width of left nav / 15 is the margin with content
-      $toc.css('left', $content.get('0').offsetLeft + $content.get('0').offsetWidth + 280 + 15 +'px');
-      // 30 is the margin with bottom window
-      $toc.css('max-height', window.innerHeight - $toc.get('0').offsetTop - 30  + 'px');
-    }
-
-    $(window).on('resize', function() {
-      clearTimeout(debounceComputeSize);
-      debounceComputeSize = setTimeout(computeSize, 13);
-    })
-    computeSize();
-  }
-  //----------------------------
 
   //---------------------------------------------------------------------
   // toogle 'active' class on toc link when headings pass window offset

--- a/src/assets/stylesheets/full/screen.scss
+++ b/src/assets/stylesheets/full/screen.scss
@@ -19,9 +19,94 @@
 
 .container {
   .page-wrapper {
+    .content {
+      @media (min-width: $desktop-width) {
+        margin: 0 0 0 50px;
+        width: 65%;
+      }
+      @media (min-width: $large-desktop-width) {
+        margin: 0 0 0 100px;
+        width: 70%;
+      }
+    }
+
     .toc {
       opacity: 1;
       transition: opacity 2s;
+      position: fixed;
+      padding: 2px 4px 9px;
+      right: 0;
+      top: 166px;
+      overflow: auto;
+      border-left: solid 6px #dedede;
+      width: 230px;
+      transition: all 0.1s;
+
+      @media (max-width: $desktop-width) {
+        opacity: 0;
+      }
+      @media (min-width: $large-desktop-width) {
+        left: auto;
+        right: 0;
+      }
+
+      .toc-level-2 {
+        a {
+          &:before {
+            padding-left: 2px;
+            padding-right: 2px;
+            content: "›";
+          }
+        }
+      }
+      .toc-level-6,
+      .toc-level-5,
+      .toc-level-4,
+      .toc-level-3 {
+        a {
+          padding-left: 15px
+        }
+      }
+
+      ul {
+        margin: 0;
+        li {
+          padding: 3px 6px;
+          list-style: none;
+
+          // &.toc-level-1 {
+          //   font-size: 14px;
+          // }
+          // &.toc-level-2 {
+          //   font-size: 13px;
+          // }
+          // &.toc-level-3 {
+          //   font-size: 12px;
+          // }
+          // &.toc-level-4 {
+          //   font-size: 11px;
+          // }
+
+          a {
+            color: #333;
+            text-decoration: none;
+            font-size: 12px;
+            transition: color 0.2s;
+
+            &:hover {
+              color: #002835;
+              text-decoration: underline;
+            }
+
+            &.active {
+              color: #3498e4;
+              &:before {
+                color: #3498e4;
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/layouts/category-members.html.hbs
+++ b/src/layouts/category-members.html.hbs
@@ -5,7 +5,7 @@
 
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.7.0/styles/atom-one-light.min.css">
 
-  <link href="{{ site_base_path }}assets/stylesheets/full/screen.css" rel="stylesheet" type="text/css" media="screen" />
+  <link href="{{ site_base_path }}assets/stylesheets/side-code/screen.css" rel="stylesheet" type="text/css" media="screen" />
 </head>
 
 <body class="index">

--- a/src/layouts/full.html.hbs
+++ b/src/layouts/full.html.hbs
@@ -18,6 +18,18 @@
   {{/unless}}
 
   <div class="page-wrapper">
+    <div class="toc">
+      <ul data-turbolinks="false">
+        {{#each toc}}
+        <li class="toc-item toc-level-{{level}}">
+            <a href="#{{ id }}" title="{{ title }}">
+              {{ title }}
+            </a>
+        </li>
+        {{/each}}
+      </ul>
+    </div>
+
     <div class="content">
       <div class="main-content">
         <!-- <div class="reading-time"><p>Reading time: {{#wordsToTime}}{{/wordsToTime}} min</p></div> -->


### PR DESCRIPTION
## What does this PR do ?

In older versions of the documentation, we had a table of content in the right column of pages, which enabled to navigate inside long pages.
This toc had gone and that makes the navigation not satisfying (see example the [plugin context description](https://docs.kuzzle.io/plugins-reference/plugins-context/accessors) for example)

This PR get back this TOC.

### How should this be manually tested?

Preview the documentation in netlify: https://lucid-wescoff-f092bc.netlify.com/

example with the plugin context description: https://lucid-wescoff-f092bc.netlify.com/plugins-reference/plugins-context/accessors

### Screenshot


![kuzzle-doc-right-toc](https://user-images.githubusercontent.com/1447135/40533982-be372460-6004-11e8-9f78-6c9e2f07eea8.png)
