### PR TITLE
Update metadata

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!--
-  This template is not mandatory.
+  This template is optional.
   It simply serves to provide a guide to allow a better review of pull requests.
 -->
 
@@ -11,7 +11,7 @@
 
 
 ## What does this PR do ?
-<!-- Please fulfill this section -->
+<!-- Please fill this section -->
 
 <!--
   Please include a summary of the change and which issue is fixed.

--- a/src/api-documentation/controller-document/get.md
+++ b/src/api-documentation/controller-document/get.md
@@ -60,11 +60,24 @@ title: get
         "last": "Wozniak"
       },
       "hobby": "Segway polo",
+      // Kuzzle metadata
+      "_kuzzle_info": {
+        "author": "Bob",
+        "createdAt": 1481816934209,
+        "updatedAt": null,
+        "updater": null,
+        "active": true,
+        "deletedAt": null
+      }
       ...
     },
     "_meta": {
       "author": "Bob",
-      ...
+      "createdAt": 1481816934209,
+      "updatedAt": null,
+      "updater": null,
+      "active": true,
+      "deletedAt": null
     }
   }
 }

--- a/src/api-documentation/notifications/index.md
+++ b/src/api-documentation/notifications/index.md
@@ -35,7 +35,7 @@ A document notification contains the following fields:
 | `index` | string | The modified data index | |
 | `protocol` | string | The network protocol used to modify the document | |
 | `result._id` | string | The document identifier. Can be null if the document doesn't exist yet, or if the notification is about a real-time message | |
-| `result._meta` | object | Document meta-data (creation time, last update time, and so on). Can be null. | |
+| `result._meta` | object | DEPRECATED in 1.3.0 - Document meta-data (creation time, last update time, and so on). Can be null. | |
 | `result._source` | object | The message or full document content. Undefined if the notification is about a document deletion |
 | `result._source._kuzzle_info` | object | Document meta-data (creation time, last update time, and so on). Can be null. |
 | `scope` | string | Indicates if the document enters or exits the subscription scope | `in`, `out` |

--- a/src/api-documentation/notifications/index.md
+++ b/src/api-documentation/notifications/index.md
@@ -22,8 +22,8 @@ Document notifications can be sent to subscribers:
 * On Document Creation Pending: a document is about to be created (the creation is not guaranteed)
 * On Document Deletion: A document has been deleted
 * On Document Deletion Pending: A document is about to be deleted (the deletion is not guaranteed)
-* On Document Entering Subscription Scope: a document has been updated and enters the subscription scope 
-* On Document Exiting Subscription Scope: a document has been updated and exits the subscription scope 
+* On Document Entering Subscription Scope: a document has been updated and enters the subscription scope
+* On Document Exiting Subscription Scope: a document has been updated and exits the subscription scope
 
 A document notification contains the following fields:
 
@@ -37,6 +37,7 @@ A document notification contains the following fields:
 | `result._id` | string | The document identifier. Can be null if the document doesn't exist yet, or if the notification is about a real-time message | |
 | `result._meta` | object | Document meta-data (creation time, last update time, and so on). Can be null. | |
 | `result._source` | object | The message or full document content. Undefined if the notification is about a document deletion |
+| `result._source._kuzzle_info` | object | Document meta-data (creation time, last update time, and so on). Can be null. |
 | `scope` | string | Indicates if the document enters or exits the subscription scope | `in`, `out` |
 | `state` | string | Shows if the document is about to be changed, or if the change is done | `pending`, `done` |
 |`timestamp` | number | Timestamp of the request from which is issued this notification (in epoch-milliseconds) | |

--- a/src/guide/essentials/document-metadata.md
+++ b/src/guide/essentials/document-metadata.md
@@ -27,7 +27,10 @@ Metadata can be viewed in the document's `_kuzzle_info` field and contains the f
 * `active`: The status of the document. `true` if the document is active and `false` if the document has been put in the trashcan.
 * `deletedAt`: Timestamp of document deletion in epoch-milliseconds format, or `null` if the document has not been deleted.
 
+
 Here is an example of a Kuzzle response, containing a document's `_id`, `_source` and `_meta` fields:
+
+{{{deprecated "1.3.0"}}}
 
 ```json
 {
@@ -49,9 +52,10 @@ Here is an example of a Kuzzle response, containing a document's `_id`, `_source
 }
 ```
 
-{{{since "1.3.0"}}}
 
 Here is an example of a Kuzzle response, containing a document's `_id` and `_source` fields:
+
+{{{since "1.3.0"}}}
 
 ```json
 {

--- a/src/guide/essentials/document-metadata.md
+++ b/src/guide/essentials/document-metadata.md
@@ -15,6 +15,11 @@ Whenever a document gets created, updated or deleted, Kuzzle will add or update 
 
 Metadata can be viewed in the document's `_meta` field and contains the following properties:
 
+{{{since "1.3.0"}}}
+
+Metadata can be viewed in the document's `_kuzzle_info` field and contains the following properties:  
+
+
 * `author`: The [unique identifier]({{ site_base_path }}guide/essentials/user-authentication/#kuzzle-user-identifier-kuidd) of the user who created the document.
 * `createdAt`: Timestamp of document creation (create or replace), in epoch-milliseconds format.
 * `updatedAt`: Timestamp of last document update in epoch-milliseconds format, or `null` if no update has been made.
@@ -44,12 +49,36 @@ Here is an example of a Kuzzle response, containing a document's `_id`, `_source
 }
 ```
 
+{{{since "1.3.0"}}}
+
+Here is an example of a Kuzzle response, containing a document's `_id` and `_source` fields:
+
+```json
+{
+  "_index": "myindex",
+  "_type": "mycollection",
+  "_id": "AVkDLAdCsT6qHI7MxLz4",
+  "_score": 0.25811607,
+  "_source": {
+    "message": "Hello World!",
+    "_kuzzle_info": {
+      "author": "<kuid>",
+      "createdAt": 1481816934209,
+      "updatedAt": null,
+      "updater": null,
+      "active": true,
+      "deletedAt": null
+    }
+  }
+}
+```
+
 ---
 
 ## How metadata are physically stored
 
-Documents metadata is managed by Kuzzle and cannot be changed using the API.  
-Metadata is stored in the _kuzzle_info field of each document in Elasticsearch.
+Documents metadata are managed by Kuzzle and cannot be changed using the API.  
+Metadata are stored in the `_kuzzle_info` field of each document in Elasticsearch.
 
 Elasticsearch might contain documents that don't have metadata. This can be the case for documents that were not inserted through Kuzzle. Such documents will automatically obtain metadata when they are updated through Kuzzle.
 

--- a/src/guide/essentials/document-metadata.md
+++ b/src/guide/essentials/document-metadata.md
@@ -52,10 +52,9 @@ Here is an example of a Kuzzle response, containing a document's `_id`, `_source
 }
 ```
 
+{{{since "1.3.0"}}}
 
 Here is an example of a Kuzzle response, containing a document's `_id` and `_source` fields:
-
-{{{since "1.3.0"}}}
 
 ```json
 {

--- a/src/guide/essentials/persisted.md
+++ b/src/guide/essentials/persisted.md
@@ -27,7 +27,7 @@ Kuzzle automatically generates document ids and indexes them. The generated id i
 
 We will start off by [**creating a new index**]({{ site_base_path }}api-documentation/controller-index/create/) which we will use to store a collection.
 
-To create a new index, send a `POST` request to the following API endpoint and leave the request body empty:  `http://localhost:7512/<index name>/_create`. 
+To create a new index, send a `POST` request to the following API endpoint and leave the request body empty:  `http://localhost:7512/<index name>/_create`.
 
 
 Let's create an index named `myindex`:
@@ -87,7 +87,7 @@ You should receive the following response:
 
 **Note:**  we have just created a new collection without specifying any mappings. As a result, the database layer will automatically create a mapping that assigns a best guess data type to any new field it detects in input documents. Since these mappings cannot be changed once they are created, we strongly recommend that you [**create your own mappings**]({{ site_base_path }}guide/essentials/persisted/#mappings) as soon as the collection has been created. For the purpose of this tutorial, we will continue without defining our own mappings.
 
---- 
+---
 
 ## Browse Collections
 
@@ -137,7 +137,7 @@ Kuzzle ships with a full data [CRUD](https://en.wikipedia.org/wiki/Create,_read,
 
 We can [**create a new document**]({{ site_base_path }}api-documentation/controller-document/create) by sending a `POST` request to the following API endpoint and setting the document contents in the request body: `http://localhost:7512/<index name>/<collection name>/_create`.
 
-Let's create a new document in the `mycollection` collection of the `myindex` index: 
+Let's create a new document in the `mycollection` collection of the `myindex` index:
 
 ```bash
  curl -X POST -H "Content-Type: application/json" -d '{"message": "Hello World!"}' http://localhost:7512/myindex/mycollection/_create
@@ -169,7 +169,15 @@ You should receive the following response (with your own `_id` value):
     },
     "created": true,
     "_source": {
-      "message": "Hello World!"
+      "message": "Hello World!",
+      "_kuzzle_info": {
+        "author": "-1",
+        "createdAt": 1481814465050,
+        "updatedAt": null,
+        "updater": null,
+        "active": true,
+        "deletedAt": null
+      }
     },
     "_meta": {
       "author": "-1",
@@ -192,7 +200,7 @@ Note that the document contains the auto-generated id `AVkDBl3YsT6qHI7MxLz0`. Ta
 
 We can [**read a document**]({{ site_base_path }}api-documentation/controller-document/get)  by sending a `GET` request to `http://localhost:7512/<index name>/<collection name>/<document id>`.
 
-Let's read the document we just created in the `mycollection` collection of the `myindex` index: 
+Let's read the document we just created in the `mycollection` collection of the `myindex` index:
 
 ```bash
  curl http://localhost:7512/myindex/mycollection/AVkDBl3YsT6qHI7MxLz0
@@ -217,15 +225,13 @@ You should receive the following response (with your own `_id` value):
     "_version": 1,
     "found": true,
     "_source": {
-      "message": "Hello World!"
+      "message": "Hello World!",
+      "_kuzzle_info": {
+        ...
+      }
     },
     "_meta": {
-      "author": "-1",
-      "createdAt": 1481814465050,
-      "updatedAt": null,
-      "updater": null,
-      "active": true,
-      "deletedAt": null
+      ...
     }
   }
 }
@@ -235,7 +241,7 @@ You should receive the following response (with your own `_id` value):
 
 We can [**update a document**]({{ site_base_path }}api-documentation/controller-document/update) by sending a `PUT` request to the following API endpoint and setting the document's updated contents in the request body: `http://localhost:7512/<index name>/<collection name>/<document id>/_update`.
 
-Let's update the document we just created, with id `AVkDBl3YsT6qHI7MxLz0`, in the `mycollection` collection of the `myindex` index: 
+Let's update the document we just created, with id `AVkDBl3YsT6qHI7MxLz0`, in the `mycollection` collection of the `myindex` index:
 
 
 ```bash
@@ -275,7 +281,7 @@ You should receive the following response (with your own `_id` value):
 
 We can [**delete a document**]({{ site_base_path }}api-documentation/controller-document/delete)  by sending a `DELETE` request to the following API endpoint with no request body: `http://localhost:7512/<index name>/<collection name>/<document id>`.
 
-Let's delete the document we just created in the `mycollection` collection of the `myindex` index: 
+Let's delete the document we just created in the `mycollection` collection of the `myindex` index:
 
 ```bash
  curl -X DELETE http://localhost:7512/myindex/mycollection/AVkDBl3YsT6qHI7MxLz0
@@ -317,7 +323,7 @@ One thing that Elasticsearch is _really_ good at doing is... Searching! Thanks t
 
 Say we want to [**find**]({{ site_base_path }}api-documentation/controller-document/search) all documents in the `mycollection` collection. Whe can do this by sending a `POST` request to `http://localhost:7512/<index name>/<collection name>/_search` and setting any search filters in the request body.
 
-As an example, let's create some documents in the `mycollection` collection of the `myindex` index and then search for them: 
+As an example, let's create some documents in the `mycollection` collection of the `myindex` index and then search for them:
 
 First, let's create a few documents, since at this point our collection is empty:
 
@@ -362,15 +368,13 @@ You should receive the following response (with your own `_id` values):
         "_id": "AWD-hP9Y2f6djIwk5oeW",
         "_score": 0,
         "_source": {
-          "message": "Bonjour!"
+          "message": "Bonjour!",
+          "_kuzzle_info": {
+            ...
+          }
         },
         "_meta": {
-          "author": "-1",
-          "createdAt": 1516098617157,
-          "updatedAt": null,
-          "updater": null,
-          "active": true,
-          "deletedAt": null
+          ...
         }
       },
       {
@@ -379,15 +383,13 @@ You should receive the following response (with your own `_id` values):
         "_id": "AWD-hQ_N2f6djIwk5oeX",
         "_score": 0,
         "_source": {
-          "message": "Hello!"
+          "message": "Hello!",
+          "_kuzzle_info": {
+            ...
+          }
         },
         "_meta": {
-          "author": "-1",
-          "createdAt": 1516098621387,
-          "updatedAt": null,
-          "updater": null,
-          "active": true,
-          "deletedAt": null
+          ...
         }
       },
       {
@@ -396,15 +398,13 @@ You should receive the following response (with your own `_id` values):
         "_id": "AWD-hSjM2f6djIwk5oeZ",
         "_score": 0,
         "_source": {
-          "message": "Goodbye!"
+          "message": "Goodbye!",
+          "_kuzzle_info": {
+            ...
+          }
         },
         "_meta": {
-          "author": "-1",
-          "createdAt": 1516098627787,
-          "updatedAt": null,
-          "updater": null,
-          "active": true,
-          "deletedAt": null
+          ...
         }
       },
       {
@@ -413,15 +413,13 @@ You should receive the following response (with your own `_id` values):
         "_id": "AWD-hR2H2f6djIwk5oeY",
         "_score": 0,
         "_source": {
-          "message": "Au revoir!"
+          "message": "Au revoir!",
+          "_kuzzle_info": {
+            ...
+          }
         },
         "_meta": {
-          "author": "-1",
-          "createdAt": 1516098624901,
-          "updatedAt": null,
-          "updater": null,
-          "active": true,
-          "deletedAt": null
+          ...
         }
       }
     ],
@@ -477,15 +475,13 @@ You should receive the following response (with your own `_id` values):
         "_id": "AWD-hQ_N2f6djIwk5oeX",
         "_score": 0.6931472,
         "_source": {
-          "message": "Hello!"
+          "message": "Hello!",
+          "_kuzzle_info": {
+            ...
+          }
         },
         "_meta": {
-          "author": "-1",
-          "createdAt": 1516098621387,
-          "updatedAt": null,
-          "updater": null,
-          "active": true,
-          "deletedAt": null
+          ...
         }
       }
     ],


### PR DESCRIPTION

## What does this PR do ?

This PR deprecate the usage of the `_meta` field for the `_kuzzle_info` field inside document body.

See https://github.com/kuzzleio/kuzzle/pull/1121

### How should this be manually tested?

<!--
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->
  - Step 1 :

### Other changes

  - Update pr template

### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/4447392/40718268-b721b794-640f-11e8-80bf-c358c90a4be5.png)

