### PR TITLE
Document controller actions: fix query body format

### DIFF
--- a/src/api-documentation/controller-document/count.md
+++ b/src/api-documentation/controller-document/count.md
@@ -26,19 +26,19 @@ title: count
   // Use "query" instead of "filter" if you want to perform a query instead.
   "filter": {
     ...
-  },
+  }
 }
 ```
 
 
-<blockquote class="js">
+<blockquote class="json">
 <p>
 **Query:**
 </p>
 </blockquote>
 
 
-```js
+```json
 {
   "index": "<index>",
   "collection": "<collection>",
@@ -47,16 +47,15 @@ title: count
 
   "body": {
     "filter": {}
-  }
+  },
 
-  // Optional arguments
   "includeTrash": false
 }
 ```
 
 >**Response**
 
-```js
+```javascript
 {
   "status": 200,
   "error": null,

--- a/src/api-documentation/controller-document/count.md
+++ b/src/api-documentation/controller-document/count.md
@@ -27,21 +27,18 @@ title: count
   "filter": {
     ...
   },
-
-  // Optional arguments
-  "includeTrash": false
 }
 ```
 
 
-<blockquote class="json">
+<blockquote class="js">
 <p>
 **Query:**
 </p>
 </blockquote>
 
 
-```json
+```js
 {
   "index": "<index>",
   "collection": "<collection>",
@@ -51,6 +48,9 @@ title: count
   "body": {
     "filter": {}
   }
+
+  // Optional arguments
+  "includeTrash": false
 }
 ```
 

--- a/src/api-documentation/controller-document/get.md
+++ b/src/api-documentation/controller-document/get.md
@@ -25,7 +25,7 @@ title: get
 </blockquote>
 
 
-```js
+```json
 {
   "index": "<index>",
   "collection": "<collection>",
@@ -33,14 +33,13 @@ title: get
   "action": "get",
   "_id": "<documentId>",
 
-  // Optional arguments
   "includeTrash": false
 }
 ```
 
 >**Response**
 
-```js
+```javascript
 {
   "status": 200,
   "error": null,

--- a/src/api-documentation/controller-document/m-get.md
+++ b/src/api-documentation/controller-document/m-get.md
@@ -22,19 +22,19 @@ title: mGet
 
 ```js
 {
-  "ids": ["<documentId>", "<anotherDocumentId>", ...],
+  "ids": ["<documentId>", "<anotherDocumentId>", ...]
 }
 ```
 
 
-<blockquote class="js">
+<blockquote class="json">
 <p>
 **Query:**
 </p>
 </blockquote>
 
 
-```js
+```json
 {
   "index": "<index>",
   "collection": "<collection>",
@@ -42,9 +42,8 @@ title: mGet
   "action": "mGet",
   "body": {
     "ids": ["<documentId>", "<anotherDocumentId>"]
-  }
+  },
 
-  // Optional arguments
   "includeTrash": false
 }
 ```
@@ -97,7 +96,7 @@ title: mGet
         "_type": "<collection>",
         "_version": 4,
         "found": true
-      }
+      },
       {
    // Other documents
       }

--- a/src/api-documentation/controller-document/m-get.md
+++ b/src/api-documentation/controller-document/m-get.md
@@ -23,21 +23,18 @@ title: mGet
 ```js
 {
   "ids": ["<documentId>", "<anotherDocumentId>", ...],
-
-  // Optional arguments
-  "includeTrash": false
 }
 ```
 
 
-<blockquote class="json">
+<blockquote class="js">
 <p>
 **Query:**
 </p>
 </blockquote>
 
 
-```json
+```js
 {
   "index": "<index>",
   "collection": "<collection>",
@@ -46,6 +43,9 @@ title: mGet
   "body": {
     "ids": ["<documentId>", "<anotherDocumentId>"]
   }
+
+  // Optional arguments
+  "includeTrash": false
 }
 ```
 

--- a/src/api-documentation/controller-document/search.md
+++ b/src/api-documentation/controller-document/search.md
@@ -33,14 +33,14 @@ title: search
 ```
 
 
-<blockquote class="js">
+<blockquote class="json">
 <p>
 **Query:**
 </p>
 </blockquote>
 
 
-```js
+```json
 {
   "index": "<index>",
   "collection": "<collection>",
@@ -56,7 +56,6 @@ title: search
     }
   },
 
-  // Optional arguments
   "from": 0,
   "size": 42,
   "scroll": "1m",

--- a/src/api-documentation/controller-document/search.md
+++ b/src/api-documentation/controller-document/search.md
@@ -28,25 +28,19 @@ title: search
   },
   "aggregations": {
     ...
-  },
-
-  // Optional arguments
-  "from": 0,
-  "size": 42,
-  "scroll": "1m",
-  "includeTrash": false
+  }
 }
 ```
 
 
-<blockquote class="json">
+<blockquote class="js">
 <p>
 **Query:**
 </p>
 </blockquote>
 
 
-```json
+```js
 {
   "index": "<index>",
   "collection": "<collection>",
@@ -62,9 +56,11 @@ title: search
     }
   },
 
+  // Optional arguments
   "from": 0,
   "size": 42,
-  "scroll": "<time to live>"
+  "scroll": "1m",
+  "includeTrash": false
 }
 ```
 


### PR DESCRIPTION
remove `from`, `size`, `scroll`, `includeTrash` optional arguments from query body
They must be given in queryString in HTTP, and in the root's payload in other protocols

Also fix the display of sample queries (example: https://docs.kuzzle.io/api-documentation/controller-document/get - see tab "Other protocols")

Preview:
https://deploy-preview-490--hawker-sarah-11661.netlify.com/api-documentation/controller-document/count
https://deploy-preview-490--hawker-sarah-11661.netlify.com/api-documentation/controller-document/m-get
https://deploy-preview-490--hawker-sarah-11661.netlify.com/api-documentation/controller-document/search/