### PR TITLE
Replace constructor with authenticator

### DIFF
--- a/src/plugins-reference/plugins-context/accessors.md
+++ b/src/plugins-reference/plugins-context/accessors.md
@@ -66,7 +66,7 @@ Data stored in this space cannot be accessed from Kuzzle, or from the API, or fr
 
 The only way a document stored in this space can be accessed outside the plugin is if that plugin extends the API with a route exposing that data.
 
-This storage space is a whole [data index]({{ site_base_path }}guide/essentials/persisted/#working-with-persistent-data).  
+This storage space is a whole [data index]({{ site_base_path }}guide/essentials/persisted/#working-with-persistent-data).
 
 Data stored in this space can be accessed through the [Repository constructor]({{ site_base_path }}plugins-reference/plugins-context/constructors/#repository).
 
@@ -147,17 +147,15 @@ context.accessors.storage.createCollection('someCollection', {
 
 This accessor can be used to dynamically add or remove [authentication strategies]({{ site_base_path }}guide/essentials/user-authentication/#authentication-strategy)
 
-In a cluster context, Kuzzle will add/remove strategies on all server nodes.
-
-<aside class="warning">
-Plugins should also make sure that, when changing the list of available strategies dynamically, that list will remain the same after a Kuzzle server node restarts.
-</aside>
-
 ### `add`
 
 {{{since "1.2.0"}}}
 
 Adds a new authentication strategy. Users can be authenticated using that new strategy as soon as this method resolves.
+
+If the strategy to be added already exists, the old one will be removed first, unless it has been registered by another plugin.
+
+In a cluster environment, the new strategy is automatically added to all server nodes.
 
 **Arguments**
 
@@ -173,14 +171,15 @@ This method returns a promise that resolves to nothing when the authentication s
 The promise will be rejected when:
 
 * the properties for that strategy are invalid or incomplete
-* a strategy of the same name already exists
+* a strategy of the same name has already been registered by another plugin
+* if the provided properties contain a `constructor` parameter instead of an `authenticator` one (see [Exposing Authenticators]({{site_base_path}}/plugins-reference/plugins-features/adding-authentication-strategy#exposing-authenticators))
 
 **Usage**
 
 ```js
 context.accessors.strategies.add('someStrategy', {
   config: {
-    constructor: StrategyConstructor,
+    authenticator: 'StrategyConstructorName',
     strategyOptions: {},
     authenticateOptions: {
       scope: []
@@ -205,7 +204,9 @@ context.accessors.strategies.add('someStrategy', {
 
 {{{since "1.2.0"}}}
 
-Dynamically removes a strategy, preventing new authentications from using it.  
+Dynamically removes a strategy, preventing new authentications from using it.
+
+In a cluster environment, the new strategy is automatically removed from all server nodes.
 
 <aside class="warning">
 Authentication tokens previously created using that strategy ARE NOT invalidated after using this method.

--- a/src/plugins-reference/plugins-features/adding-authentication-strategy.md
+++ b/src/plugins-reference/plugins-features/adding-authentication-strategy.md
@@ -44,9 +44,6 @@ Whether strategies are added statically or dynamically, a `strategies` object mu
 * `config`: an object containing the strategy configuration
   * `constructor`: The constructor of the Passport.js strategy. This property is **deprecated** since Kuzzle v1.4.0, and using it with a [dynamic strategy registration]({{site_base_path}}plugins-reference/plugins-context/accessors/#strategies) will throw an error. Use `authenticator` instead.
   * `authenticator`: One of the exposed [authenticators]({{site_base_path}}/plugins-reference/plugins-features/adding-authentication-strategy#exposing-authenticators) name (this property cannot be set if a `constructor` value is provided)
-  * `strategyOptions`: The options provided to the Passport.js strategy
-  * `authenticateOptions`: The options provided to the Passport's [authenticate method](http://passportjs.org/docs/authenticate).
-  * `fields`: The list of fields that can be provided to the plugin.
 * `methods`: an object containing the list of exposed methods
   * `create`: The name of the exposed [`create` function]({{site_base_path}}/plugins-reference/plugins-features/adding-authentication-strategy#the-create-function) to use
   * `delete`: The name of the exposed [`delete` function]({{site_base_path}}/plugins-reference/plugins-features/adding-authentication-strategy#the-delete-function) to use
@@ -59,6 +56,16 @@ Whether strategies are added statically or dynamically, a `strategies` object mu
   * (optional) `getInfo`: The name of the exposed [`getInfo` function]({{site_base_path}}/plugins-reference/plugins-features/adding-authentication-strategy#the-getinfo-function) to use
 
 Even though each strategy must declare its own set of properties, the same strategy method can be used by multiple strategies.
+
+
+#### Additional strategy.config properties
+
+The `strategy.config` object may contain the following optional properties:
+
+  * `authenticateOptions`: The options provided to the Passport's [authenticate method](http://passportjs.org/docs/authenticate).
+  * `fields`: An array of field names accepted by the plugin to validate credentials. The list is informative only, meant to be used by the [getAllCredentialFields]({{site_base_path}}/api-documentation/controller-security/get-all-credential-fields/) and the [getCredentialFields]({{site_base_path}}/api-documentation/controller-security/get-credential-fields) API methods.
+  * `strategyOptions`: The options provided to the Passport.js strategy constructor
+
 
 ---
 
@@ -275,35 +282,18 @@ class AuthenticationPlugin {
           // The Passport authenticator name
           authenticator: 'StrategyConstructor',
 
-          // Options provided to the strategy constructor at instantiation
-          strategyOptions: {},
-
-          // Options provided to the authenticate function during the authentication process
-          authenticateOptions: {
-            scope: []
-          },
-
           // The list of fields that have to be provided in the credentials
           fields: ['login', 'password']
         },
         methods: {
-          // (optional) The name of the afterRegister function
           afterRegister: 'afterRegister',
-          // The name of the create function
           create: 'create',
-          // The name of the delete function
           delete: 'delete',
-          // The name of the exists function
           exists: 'exists',
-          // (optional) The name of the getById function
           getById: 'getById',
-          // (optional) The name of the getInfo function
           getInfo: 'getInfo',
-          // The name of the update function
           update: 'update',
-          // The name of the validate function
           validate: 'validate',
-          // The name of the verify function
           verify: 'verify'
         }
       }
@@ -319,7 +309,7 @@ class AuthenticationPlugin {
    */
   afterRegister (constructedStrategy) {
     // do some action
-    Promise.resolve(/* any value */);
+    return Promise.resolve(/* any value */);
   }
 
   /**
@@ -334,7 +324,7 @@ class AuthenticationPlugin {
    */
   create (request, credentials, kuid) {
     // persist credentials
-    Promise.resolve(/* non sensitive credentials info */);
+    return Promise.resolve(/* non sensitive credentials info */);
   }
 
   /**
@@ -347,7 +337,7 @@ class AuthenticationPlugin {
    */
   delete (request, kuid) {
     // remove credentials
-    Promise.resolve(/* any value */);
+    return Promise.resolve(/* any value */);
   }
 
   /**
@@ -359,7 +349,7 @@ class AuthenticationPlugin {
    */
   exists (request, kuid) {
     // check credentials existence
-    Promise.resolve(/* true|false */);
+    return Promise.resolve(/* true|false */);
   }
 
   /**
@@ -373,7 +363,7 @@ class AuthenticationPlugin {
    */
   getInfo (request, kuid) {
     // retrieve credentials
-    Promise.resolve(/* non sensitive credentials info */);
+    return Promise.resolve(/* non sensitive credentials info */);
   }
 
   /**
@@ -387,7 +377,7 @@ class AuthenticationPlugin {
    */
   getById (request, id) {
     // retrieve credentials
-    Promise.resolve(/* non sensitive credentials info */);
+    return Promise.resolve(/* non sensitive credentials info */);
   }
 
   /**
@@ -401,7 +391,7 @@ class AuthenticationPlugin {
    */
   update (request, credentials, kuid) {
     // update credentials
-    Promise.resolve(/* non sensitive credentials info */);
+    return Promise.resolve(/* non sensitive credentials info */);
   }
 
   /**
@@ -418,7 +408,7 @@ class AuthenticationPlugin {
    */
   validate (request, credentials, kuid, strategy, isUpdate) {
     // validate credentials
-    Promise.resolve(/* true|false */);
+    return Promise.resolve(/* true|false */);
   }
 
   /**


### PR DESCRIPTION
## What does this PR do?

* Document the new `authenticators` property, that auth. plugins now need to implement if they need to register/remove strategies during runtime
* Document the new `strategy.config.authenticator` property
* Deprecate the `strategy.config.constructor` property
* Make the `strategy.config.strategyOptions`, `strategy.config.fields` and the `strategy.config.authenticateOptions` optional
* Fix missing `return` statements in the auth. plugin code example
