### PR TITLE
Improve disconnect() documentation

### DIFF
--- a/src/sdk-reference/kuzzle/disconnect.md
+++ b/src/sdk-reference/kuzzle/disconnect.md
@@ -23,6 +23,6 @@ kuzzle.disconnect();
 // not implemented (this SDK uses HTTP and is thus stateless)
 ```
 
-Closes the current connection.  
-Kuzzle state is now `disconnected`. You can't make any API call before an other call to [connect()]({{ site_base_path }}sdk-reference/kuzzle/connect).  
-This action does not trigger a `disconnected` event since this event is triggered when an unexpected disconnection occur.
+Closes the current connection, and frees all allocated resources.  
+Contrary to the `offline` state (when the network connection is unexpectedly lost), `disconnect()`  invalidates the instance, which cannot be used until [connect()]({{ site_base_path }}sdk-reference/kuzzle/connect) is explicitly called.  
+This action does not trigger a `disconnected` event since this event is triggered when an unexpected disconnection occur.  

--- a/src/sdk-reference/kuzzle/disconnect.md
+++ b/src/sdk-reference/kuzzle/disconnect.md
@@ -1,5 +1,5 @@
 ---
-layout: side-code.html.hbs
+layout: side-code.html
 language-tab:
   js: Javascript
   java: Android
@@ -23,4 +23,6 @@ kuzzle.disconnect();
 // not implemented (this SDK uses HTTP and is thus stateless)
 ```
 
-Closes the current connection.
+Closes the current connection.  
+Kuzzle state is now `disconnected`. You can't make any API call before an other call to [connect()]({{ site_base_path }}sdk-reference/kuzzle/connect).  
+This action does not trigger a `disconnected` event since this event is triggered when an unexpected disconnection occur.


### PR DESCRIPTION
## What does this PR do ?

Specifies that the method `disconnect()` does not trigger the `disconnected` event.  
The behaviour was unclear for some people (https://github.com/kuzzleio/sdk-javascript/issues/298).  

### Screenshots

![image](https://user-images.githubusercontent.com/4447392/42868181-f7babe8a-8a71-11e8-87a1-5a631a11bc5a.png)
