### PR TITLE
Fix security:search[Roles|Profiles|Users] documentation

### DIFF
--- a/src/api-documentation/controller-security/search-profiles.md
+++ b/src/api-documentation/controller-security/search-profiles.md
@@ -27,12 +27,7 @@ title: searchProfiles
   "roles": [
     "someRole",
     "admin"
-  ],
-
-  // optional: result pagination configuration
-  "from": 0,
-  "size": 42,
-  "scroll": "<ttl>"
+  ]
 }
 ```
 

--- a/src/api-documentation/controller-security/search-profiles.md
+++ b/src/api-documentation/controller-security/search-profiles.md
@@ -27,7 +27,7 @@ title: searchProfiles
   "roles": [
     "someRole",
     "admin"
-  ]
+  ],
 
   // optional: result pagination configuration
   "from": 0,

--- a/src/api-documentation/controller-security/search-profiles.md
+++ b/src/api-documentation/controller-security/search-profiles.md
@@ -13,7 +13,6 @@ title: searchProfiles
 {{{since "1.0.0"}}}
 
 
-
 <blockquote class="js">
 <p>
 **URL:** `http://kuzzle:7512/profiles/_search[?from=0][&size=42][&scroll=<time to live>]`  
@@ -24,11 +23,16 @@ title: searchProfiles
 
 ```js
 {
-  // An array of roles used by the searched profiles
+  // optional: search only for profiles referring the listed roles
   "roles": [
-    "firstRoleId",
+    "someRole",
     "admin"
   ]
+
+  // optional: result pagination configuration
+  "from": 0,
+  "size": 42,
+  "scroll": "<ttl>"
 }
 ```
 
@@ -44,14 +48,14 @@ title: searchProfiles
   "action": "searchProfiles",
   "body": {
     "roles": [
-      "myRoleId",
+      "someRole",
       "admin"
     ]
   },
-
+  // optional: result pagination configuration
   "from": 0,
   "size": 42,
-  "scroll": "<time to live>"
+  "scroll": "<ttl>"
 }
 ```
 
@@ -63,54 +67,34 @@ title: searchProfiles
   "error": null,                     
   "result":
   {
-    "_shards": {
-      "failed": 0,
-      "successful": 5,
-      "total": 5
-    },
     "hits": [
       {
         "_id": "firstProfileId",
         "_source": {
-          "policies": [
-            {
-              "roleId": "firstRoleId",
-              "restrictedTo": [
-                ...
-              ]
-            },
-            ...
-          ]
+          // Full profile definition
         }
       },
       {
         "_id": "secondProfileId",
         "_source": {
-          "policies": [
-            {
-              "roleId": "admin"
-            },
-            ...
-          ]
+          // Full profile definition
         }
       }
     ],
     "total": 2
   },
-  "index": "%kuzzle",
-  "collection": "profiles"
   "action": "searchProfiles",
   "controller": "security",
   "requestId": "<unique request identifier>"
 }
 ```
 
-Returns profiles linked to a given set of roles.
+Search for security profiles, optionally returning only those linked to the provided list of security roles.
 
 
 Optional arguments:
 
 * `body.roles` contains an array of role identifiers used to filter the search results
-* `size` controls the maximum number of documents returned in the response
+* `size` controls the maximum number of documents returned in one response page
 * `from` is usually used with the `size` argument, and defines the offset from the first result you want to fetch
 * `scroll` is used to fetch large result sets, and it must be set with a [time duration](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/common-options.html#time-units). If set, a forward-only cursor will be created (and automatically destroyed at the end of the set duration), and its identifier will be returned in the `scrollId` property, along with the first page of the results. This cursor can then be moved forward using the [`scrollProfiles` API action]({{ site_base_path }}api-documentation/controller-security/scroll-profiles)

--- a/src/api-documentation/controller-security/search-roles.md
+++ b/src/api-documentation/controller-security/search-roles.md
@@ -13,7 +13,6 @@ title: searchRoles
 {{{since "1.0.0"}}}
 
 
-
 <blockquote class="js">
 <p>
 **URL:** `http://kuzzle:7512/roles/_search[?from=0][&size=42]`  
@@ -25,8 +24,13 @@ title: searchRoles
 
 ```js
 {
-  // indexes must be an array of controllers
-  "controllers": ["aController", "anotherController"]
+  // optional: retrieve only roles giving access to the
+  // provided controller names
+  "controllers": ["document", "security"],
+
+  // optional: result pagination configuration
+  "from": 0,
+  "size": 42
 }
 ```
 
@@ -41,8 +45,11 @@ title: searchRoles
   "controller": "security",
   "action": "searchRoles",
   "body": {
-    "controllers": ["aController", "anotherController"],
+    // optional: search for roles allowing access to the provided
+    // list of controllers
+    "controllers": ["document", "security"],
 
+    // optional: result pagination configuration
     "from": 0,
     "size": 42
   }
@@ -54,49 +61,29 @@ title: searchRoles
 ```javascript
 {
   "action": "searchRoles",
-  "collection": "roles",
   "controller": "security",
   "error": null,
-  "index": "%kuzzle",
-  "volatile": {},
   "requestId": "<unique request identifier>",
-  "result":
+  "result": 
   {
-     "_shards": {
-       "failed": 0,
-       "successful": 5,
-       "total": 5
-     },
-     "hits": [
-       {
-         "_id": "<roleId>",
-         "_index": "%kuzzle",
-         "_score": 1,
-         "_source": {
-           "controllers": {
-             // Rights for each controllers and actions can be found here
-           }
-         },
-         "_type": "roles"
-       }
-     ],
-     "max_score": null,
-     "timed_out": false,
-     "took": 1,
-     "total": 1
-  },
+    "hits": [
+      {
+        "_id": "<roleId>",
+        "_source": {
+          "controllers": {
+            // Rights for each controllers and actions can be found here
+          }
+        }
+      }
+    ]
+  }
   "status": 200
 }
 ```
 
-Returns all roles linked to a given `indexes`.
+Search for security roles, optionally returning only those allowing access to the provided controller names.
 
-Attribute `indexes` in body is optional.
-
-The `from` and `size` arguments allow pagination.
-
-Available filters:
-
-| Filter | Type | Description | Default |
-|---------------|---------|----------------------------------------|---------|
-| ``indexes`` | array | List of index ids related to the searched role | ``undefined`` |
+Optional arguments:
+* `body.controllers`: an array of controller names. Used to retrieve only security roles giving access to those controllers
+* `from`: result starting offset (default: `0`)
+* `size`: number of roles per result page (default: `10`)

--- a/src/api-documentation/controller-security/search-roles.md
+++ b/src/api-documentation/controller-security/search-roles.md
@@ -61,6 +61,7 @@ title: searchRoles
   "requestId": "<unique request identifier>",
   "result": 
   {
+    "total": 1,
     "hits": [
       {
         "_id": "<roleId>",

--- a/src/api-documentation/controller-security/search-roles.md
+++ b/src/api-documentation/controller-security/search-roles.md
@@ -68,6 +68,10 @@ title: searchRoles
         "_source": {
           "controllers": {
             // Rights for each controllers and actions can be found here
+            "*": {
+                "actions": {
+                    "*": true
+                }
           }
         }
       }
@@ -78,6 +82,8 @@ title: searchRoles
 ```
 
 Search for security roles, optionally returning only those allowing access to the provided controller names.
+
+Returned roles documents follow the format described in our [Kuzzle Security Guide](https://docs.kuzzle.io/guide/essentials/security/#defining-roles)
 
 Optional arguments:
 * `body.controllers`: an array of controller names. Used to retrieve only security roles giving access to those controllers

--- a/src/api-documentation/controller-security/search-roles.md
+++ b/src/api-documentation/controller-security/search-roles.md
@@ -26,11 +26,7 @@ title: searchRoles
 {
   // optional: retrieve only roles giving access to the
   // provided controller names
-  "controllers": ["document", "security"],
-
-  // optional: result pagination configuration
-  "from": 0,
-  "size": 42
+  "controllers": ["document", "security"]
 }
 ```
 
@@ -47,12 +43,11 @@ title: searchRoles
   "body": {
     // optional: search for roles allowing access to the provided
     // list of controllers
-    "controllers": ["document", "security"],
-
-    // optional: result pagination configuration
-    "from": 0,
-    "size": 42
-  }
+    "controllers": ["document", "security"]
+  },
+  // optional: result pagination configuration
+  "from": 0,
+  "size": 42
 }
 ```
 

--- a/src/api-documentation/controller-security/search-users.md
+++ b/src/api-documentation/controller-security/search-users.md
@@ -24,11 +24,11 @@ title: searchUsers
 
 ```js
 {
-  "filter": {
-    "and": [
+  "bool": {
+    "must": [
       {
         "in": {
-          "profileId": ["anonymous", "default"],
+          "profileIds": ["anonymous", "default"]
         }
       },
       {
@@ -56,14 +56,11 @@ title: searchUsers
   "controller": "security",
   "action": "searchUsers",
   "body": {
-    "filter": {
-      "and": [
+    "bool": {
+      "must": [
         {
           "in": {
-            "profileId": [
-              "anonymous",
-              "default"
-            ],
+            "profileIds": ["anonymous", "default"]
           }
         },
         {
@@ -78,7 +75,6 @@ title: searchUsers
       ]
     }
   },
-
   "from": 0,
   "size": 10,
   "scroll": "<time to live>"
@@ -91,13 +87,11 @@ title: searchUsers
 {
   "status": 200,                     
   "error": null,                     
-  "index": "%kuzzle",
-  "collection": "users",
-  "action": "search",
+  "action": "searchUsers",
   "controller": "security",
   "requestId": "<unique request identifier>",
   "result": {
-    "total": "<total number of users matching the filter>",
+    "total": <total number of users matching the filter>,
     // An array of user objects
     "hits": [
       {

--- a/src/api-documentation/controller-security/search-users.md
+++ b/src/api-documentation/controller-security/search-users.md
@@ -12,8 +12,6 @@ title: searchUsers
 
 {{{since "1.0.0"}}}
 
-
-
 <blockquote class="js">
 <p>
 **URL:** `http://kuzzle:7512/users/_search[?from=0][&size=42][&scroll=<time to live>]`  
@@ -27,7 +25,7 @@ title: searchUsers
   "bool": {
     "must": [
       {
-        "in": {
+        "terms": {
           "profileIds": ["anonymous", "default"]
         }
       },
@@ -35,8 +33,8 @@ title: searchUsers
         "geo_distance": {
           "distance": "10km",
           "pos": {
-            "lat": "48.8566140",
-            "lon": "2.352222"
+            "lat": 48.8566140,
+            "lon": 2.352222
           }
         }
       }
@@ -96,17 +94,23 @@ title: searchUsers
     "hits": [
       {
         "_id": "<kuid>",
-        "_source": { ... }             // The user object content
+        "_source": {
+          // User content
+        }
       },
       {
-        ...
+        "_id": "<another kuid>",
+        "_source" {
+          // Another user content
+        }
       }
     ]
   }
 }
 ```
 
-Return users matching the given filter.
+Return users matching the given filter.  
+The filter syntax follows [Elasticsearch's Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/query-filter-context.html)
 
 Optional arguments:
 

--- a/src/sdk-reference/security/search-roles.md
+++ b/src/sdk-reference/security/search-roles.md
@@ -17,14 +17,16 @@ const filters = {
   controllers:  ['document']
 };
 
-  // optional result pagination configuration
+// optional result pagination configuration
+const options = {
   from: 0,
   size: 10
+};
 
 // Using callbacks (NodeJS or Web Browser)
 kuzzle
   .security
-  .searchRoles(filters, function(error, result) {
+  .searchRoles(filters, options, function(error, result) {
     // result is a JSON Object with the following properties:
     // {
     //   total: <number of found roles>,
@@ -35,7 +37,7 @@ kuzzle
 // Using promises (NodeJS)
 kuzzle
   .security
-  .searchRolesPromise(filters)
+  .searchRolesPromise(filters, options)
   .then(result => {
     // result is a JSON Object with the following properties:
     // {
@@ -60,11 +62,9 @@ options.setFrom((long) 0);
 options.setSize((long) 42);
 options.setScroll("1m");
 
-
-
 kuzzle
   .security
-  .searchRoles(filter, new ResponseListener<SecurityDocumentList>() {
+  .searchRoles(filter, options, new ResponseListener<SecurityDocumentList>() {
     @Override
     public void onSuccess(SecurityDocumentList roles) {
       // roles.getDocuments() returns a roles list

--- a/src/sdk-reference/security/search-roles.md
+++ b/src/sdk-reference/security/search-roles.md
@@ -11,13 +11,15 @@ title: searchRoles
 # searchRoles
 
 ```js
-var filters = {
-   // filter can contains an array `controllers` with a list of controller name
-  controllers:  ['read', 'write'],
-  // filter can handler pagination with properties `from` and `size`
+// optional: retrieve only roles allowing access to the
+// provided controller names
+const filters = {
+  controllers:  ['document']
+};
+
+  // optional result pagination configuration
   from: 0,
   size: 10
-};
 
 // Using callbacks (NodeJS or Web Browser)
 kuzzle
@@ -25,8 +27,8 @@ kuzzle
   .searchRoles(filters, function(error, result) {
     // result is a JSON Object with the following properties:
     // {
-    //   total: <number of found profiles>,
-    //   documents: [<Role object>, <Role object>, ...]
+    //   total: <number of found roles>,
+    //   roles: [<Role object>, <Role object>, ...]
     // }
   });
 
@@ -34,23 +36,30 @@ kuzzle
 kuzzle
   .security
   .searchRolesPromise(filters)
-  .then((result) => {
+  .then(result => {
     // result is a JSON Object with the following properties:
     // {
-    //   total: <number of found profiles>,
-    //   documents: [<Role object>, <Role object>, ...]
+    //   total: <number of found roles>,
+    //   roles: [<Role object>, <Role object>, ...]
     // }
   });
 ```
 
 ```java
+// optional: retrieve only roles allowing access to the
+// provided controller names
 JSONObject filter = new JSONObject()
   .put("controllers", new JSONArray()
-    .put("read")
-    .put("write")
-  )
-  .put("from", 0)
-  .put("size", 10);
+    .put("document")
+    .put("security")
+  );
+
+// optional: result pagination configuration
+Options options = new Options();
+options.setFrom((long) 0);
+options.setSize((long) 42);
+options.setScroll("1m");
+
 
 
 kuzzle
@@ -76,11 +85,17 @@ use \Kuzzle\Kuzzle;
 use \Kuzzle\Security\Role;
 use \Kuzzle\Util\RolesSearchResult;
 
+// optional: retrieve only roles allowing access to the
+// provided controller names
 $filters = [
   'controllers' => [
-    'read',
-    'write'
-  ],
+    'document',
+    'security'
+  ]
+];
+
+// optional: result pagination configuration
+$options = [
   'size' => 10,
   'from' => 0
 ];
@@ -89,7 +104,7 @@ $kuzzle = new Kuzzle('localhost');
 $security = $kuzzle->security();
 
 try {
-  $result = $security->searchRoles($filters);
+  $result = $security->searchRoles($filters, $options);
 
   // $result instanceof RolesSearchResult
 
@@ -107,13 +122,13 @@ catch (ErrorException $e) {
 ```json
 {
   "total": 124,
-  "documents": [
+  "roles": [
     // array of Role
   ]
 }
 ```
 
-Executes a search on roles according to a filter.
+Search for security roles, optionally returning only the roles giving access to the provided controller names.
 
 ---
 
@@ -121,7 +136,7 @@ Executes a search on roles according to a filter.
 
 | Arguments | Type | Description |
 |---------------|---------|----------------------------------------|
-| ``filters`` | JSON Object | List of filters to retrieves roles |
+| ``filters`` | JSON Object | Optionally contains a "controllers" array listing the controller names used to filter searched roles |
 | ``options`` | JSON Object | Optional parameters |
 | ``callback`` | function | Callback handling the response |
 
@@ -131,7 +146,7 @@ Executes a search on roles according to a filter.
 
 | Filter | Type | Description | Default |
 |---------------|---------|----------------------------------------|---------|
-| ``indexes`` | array | List of indexes id related to the searched role | ``undefined`` |
+| ``controllers`` | array | retrieve only roles allowing access to the provided names | ``[]`` |
 
 ---
 
@@ -141,10 +156,10 @@ Executes a search on roles according to a filter.
 |---------------|---------|----------------------------------------|---------|
 | ``from`` | number | Starting offset | ``0`` |
 | ``queuable`` | boolean | Make this request queuable or not  | ``true`` |
-| ``size`` | number |  Number of hits to return | ``20`` |
+| ``size`` | number |  Number of hits to return per page | ``10`` |
 
 ---
 
 ## Callback Response
 
-Return a JSON Object containing the total number of roles found and an array of [Role]({{ site_base_path }}sdk-reference/role) objects.
+Return a JSON Object

--- a/src/sdk-reference/security/search-users.md
+++ b/src/sdk-reference/security/search-users.md
@@ -12,19 +12,19 @@ title: searchUsers
 
 ```js
 const filter = {
-  'bool': {
-    'must': [
+  bool: {
+    must: [
       {
-        'terms': {
-          'profileIds': ['anonymous', 'default']
+        terms: {
+          profileIds: ['anonymous', 'default']
         }
       },
       {
-        'geo_distance': {
-          'distance': '10km',
-          'pos': {
-            'lat': 48.8566140,
-            'lon': 2.352222
+        geo_distance: {
+          distance: '10km',
+          pos: {
+            lat: 48.8566140,
+            lon: 2.352222
           }
         }
       }


### PR DESCRIPTION
## What does this PR do ?

* Fix #487: ES filters were using an obsolete syntax
* Fix #420: erroneous result examples in SDK documentation
* Fix many inconsistencies and errors in all security:search* documentation
