### PR TITLE
Errors documentation update

### DIFF
--- a/src/api-documentation/errors/index.md
+++ b/src/api-documentation/errors/index.md
@@ -87,10 +87,6 @@ An `InternalError` is thrown if Kuzzle encountered a severe unknown error.
 
 A `NotFoundError` is thrown if the requested resource could not be found (e.g. a document is requested with a non-existing id).
 
-<!---
-ParseError: not documented @TODO: remove its current usage by BadRequestError
--->
-
 ---
 
 ## PartialError
@@ -105,14 +101,12 @@ A `PartialError` can be generated, for instance, if one or several queries insid
 
 The detail of each failure can be retrieved in the `errors` property of the error object.
 
----
-
 ### Additional Properties
 
 | property | type | description |
 | -------- | ---- | ----------- |
 | `count` | integer | The number of failures encountered |
-| `errors` |  array of `KuzzleError` objects | The detailed errors of the failed actions |
+| `errors` |  array of objects | The list of failed actions |
 
 ---
 

--- a/src/plugins-reference/plugins-context/errors.md
+++ b/src/plugins-reference/plugins-context/errors.md
@@ -25,7 +25,7 @@ This class should only be used to create new Kuzzle error objects.
 
 **Status Code:** `400`
 
-Thrown when a request is malformatted.
+Thrown when a request is malformed.
 
 ```js
 const err = new context.errors.BadRequestError('error message');
@@ -105,11 +105,11 @@ const err = new context.errors.NotFoundError('error message');
 
 ## `ParseError`
 
-{{{since "1.0.0"}}}
+{{{since "1.0.0"}}} {{{deprecated "1.4.1"}}}
 
 **Status Code:** `400`
 
-Thrown when a provided resource cannot be interpreted.
+Use `BadRequestError` instead.
 
 ```js
 const err = new context.errors.ParseError('error message');


### PR DESCRIPTION
## What does this PR do ?

* Fix #472: partial errors may list any kind of objects, depending on the failed request
* ParseError objects are deprecated in favor of BadRequestError objects
