### PR TITLE
SDK: Simpler Kuzzle instance description

### DIFF
--- a/src/sdk-reference/event-emitter/index.md
+++ b/src/sdk-reference/event-emitter/index.md
@@ -8,8 +8,3 @@ description: Abstract Event Emitter class
 # Kuzzle Event Emitter
 
 The `KuzzleEventEmitter` abstract class is used by [Kuzzle]({{ site_base_path }}sdk-reference/kuzzle/) and [Room]({{ site_base_path }}sdk-reference/room/) instances to emit and listen to events (see [Event Handling]({{ site_base_path }}sdk-reference/essentials/events/) section).
-
-These objects expose a `on()` method that allows one or more callbacks to be attached to named events emitted by the object.
-
-In javascript, `KuzzleEventEmitter` inherits from NodeJS's [EventEmitter](https://nodejs.org/api/events.html) prototype.
-In other languages, a subset of these methods is implemented.

--- a/src/sdk-reference/kuzzle/index.md
+++ b/src/sdk-reference/kuzzle/index.md
@@ -47,7 +47,7 @@ $kuzzle = new Kuzzle('localhost', [
 
 This is the main entry point to communicate with Kuzzle. Every other object inherits properties from the `Kuzzle` object.
 
-`Kuzzle` object is a [KuzzleEventEmitter]({{ site_base_path }}sdk-reference/event-emitter/) instance, so that we can listen to global events.
+The `Kuzzle` class is an [event emitter]({{ site_base_path }}sdk-reference/event-emitter/).
 
 ---
 


### PR DESCRIPTION
## What does this PR do ?

Fix #438 (simpler "kuzzle as an event emitter" description)
