### PR TITLE
Fix obsolete SDK "collection:create" documentation

### DIFF
--- a/src/api-documentation/controller-collection/create.md
+++ b/src/api-documentation/controller-collection/create.md
@@ -92,6 +92,6 @@ title: create
 
 Creates a new [collection]({{ site_base_path }}guide/essentials/persisted) in Kuzzle via the persistence engine, in the provided `index`.  
 You can also provide an optional body with a data mapping that allow you to exploit the full capabilities of our
-persistent data storage layer, [ElasticSearch](https://www.elastic.co/products/elasticsearch) (check here the [mapping capabilities of ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/5.x/mapping.html)).  
+persistent data storage layer, [ElasticSearch](https://www.elastic.co/products/elasticsearch) (check here the [mapping capabilities of ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/mapping.html)).  
 
 This method will only update the mapping if the collection already exists.

--- a/src/sdk-reference/collection/create.md
+++ b/src/sdk-reference/collection/create.md
@@ -11,32 +11,62 @@ title: create
 # create
 
 ```js
+// Optional: a mapping can be provided and will be 
+// applied when the collection is created
+const mapping = {
+  properties: {
+    field1: {
+      type: '<es field type>'
+    },
+    field2: {
+      type: '<es field type>'
+    }
+  }
+};
+
 // Using callbacks (NodeJS or Web Browser)
 kuzzle
   .collection('collection', 'index')
-  .create(function (error, result) {
+  .create(mapping, function (error, result) {
     // callback called once the create operation has completed
-    // => the result is a JSON object containing the raw Kuzzle response
+    // => the result is a JSON object containing the raw Kuzzle response:
+    // {
+    //    acknowledged: true
+    // }
   });
 
 // Using promises (NodeJS only)
 kuzzle
  .collection('collection', 'index')
- .createPromise()
+ .createPromise(mapping)
  .then(result => {
-   // promise resolved once the create operation has completed
-   // => the result is a JSON object containing the raw Kuzzle response
+    // promise resolved once the create operation has completed
+    // => the result is a JSON object containing the raw Kuzzle response:
+    // {
+    //    acknowledged: true
+    // }
  });
 ```
 
 ```java
+// Optional: a mapping can be provided and will be 
+// applied when the collection is created
+JSONObject mapping = new JSONObject()
+  .put("properties", new JSONObject()
+    .put("field1", new JSONObject().put("type", "<es field type>"))
+    .put("field2", new JSONObject().put("type", "<es field type>"))
+  );
+
 kuzzle
   .collection("collection", "index")
-  .create(new ResponseListener<JSONObject>() {
+  .create(mapping, new ResponseListener<JSONObject>() {
     @Override
     public void onSuccess(JSONObject object) {
       // callback called once the create operation has completed
-      // => the result is a JSON object containing the raw Kuzzle response
+      // => the result is a JSON object containing the raw Kuzzle response:
+      // {
+      //    acknowledged: true
+      // }
     }
 
     @Override
@@ -54,8 +84,21 @@ use \Kuzzle\Kuzzle;
 $kuzzle = new Kuzzle('localhost');
 $dataCollection = $kuzzle->collection('collection', 'index');
 
+// Optional: a mapping can be provided and will be 
+// applied when the collection is created
+$mapping = [
+  'properties' => [
+    'field1' => [
+      'type' => '<es field type>'
+    ],
+    'field2' => [
+      'type' => '<es field type>'
+    ]
+  ]
+];
+
 try {
-  $result = $dataCollection->create();
+  $dataCollection->create(mapping);
 }
 catch (ErrorException $e) {
 
@@ -68,26 +111,31 @@ catch (ErrorException $e) {
 {
   "status": 200,
   "error": null,
-  "requestId": "cf1fc8b4-fd87-46c3-b0a2-3d9d2fb7d401",
-  "controller": "write",
-  "action": "createCollection",
-  "collection": "newly created collection",
+  "requestId": "<request unique identifier>",
+  "controller": "collection",
+  "action": "create",
+  "collection": "<new collection name>",
   "index": "index",
-  "volatile": {},
-  "state": "done",
-  "scope": null,
-  "result": {}
+  "volatile": null,
+  "result": {
+    "acknowledged": true
+  }
 }
 ```
 
-Create a new empty data collection, with no associated mapping.
+Creates a new [collection]({{ site_base_path }}guide/essentials/persisted) in Kuzzle via the persistence engine, in the provided `index`.  
+You can also provide an optional data mapping that allow you to exploit the full capabilities of our
+persistent data storage layer, [ElasticSearch](https://www.elastic.co/products/elasticsearch) (check here the [mapping capabilities of ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/mapping.html)).  
+
+This method will only update the mapping if the collection already exists.
 
 ---
 
-## create([options], [callback])
+## create([mapping], [options], [callback])
 
 | Arguments | Type | Description |
 |---------------|---------|----------------------------------------|
+| ``mapping`` | JSON Object | Optional data mapping |
 | ``options`` | JSON Object | Optional parameters |
 | ``callback`` | function | Optional callback |
 


### PR DESCRIPTION
## What does this PR do ?

This PR updates the existing SDK `collection:create` API action:

* update the obsolete response example
* that API action now accepts an option data mapping object, allowing to create a collection directly with a mapping associated to it

Fix #389