### PR TITLE
Fix: Documentation bugs

### DIFF
--- a/src/elasticsearch-cookbook/installation/index.md
+++ b/src/elasticsearch-cookbook/installation/index.md
@@ -30,6 +30,17 @@ sudo sysctl -w vm.max_map_count=262144
 docker run -p 9200:9200 elasticsearch:5.0
 ```
 
+
+If you get this message in Elasticsearch logs on docker image boot:
+```bash
+ERROR: bootstrap checks failed max file descriptors [16384] for elasticsearch process is too low, increase to at least [65536]
+```
+Try to launch the container with those arguments:
+```bash
+docker run -p 9200:9200 --ulimit nofile=65536:65536 elasticsearch:5.0
+```
+
+
 This will run Elasticsearch in the terminal. To stop it, you can simply exit the terminal or press Ctrl-C.
 
 The Elasticsearch instance will be accessible on port 9200 of the localhost.

--- a/src/elasticsearch-cookbook/installation/index.md
+++ b/src/elasticsearch-cookbook/installation/index.md
@@ -27,24 +27,22 @@ To launch Elasticsearch, run these commands:
 
 ```bash
 sudo sysctl -w vm.max_map_count=262144
-docker run -p 9200:9200 elasticsearch:5.0
+docker run -p 9200:9200 elasticsearch:5.4.1
 ```
-
-
-If you get this message in Elasticsearch logs on docker image boot:
-```bash
-ERROR: bootstrap checks failed max file descriptors [16384] for elasticsearch process is too low, increase to at least [65536]
-```
-Try to launch the container with those arguments:
-```bash
-docker run -p 9200:9200 --ulimit nofile=65536:65536 elasticsearch:5.0
-```
-
 
 This will run Elasticsearch in the terminal. To stop it, you can simply exit the terminal or press Ctrl-C.
 
 The Elasticsearch instance will be accessible on port 9200 of the localhost.
 If you installed Elasticsearch using another method, adapt the examples provided in this cookbook to your installation configuration.
+
+If you get the following message in Elasticsearch logs during the docker image boot sequence:
+```bash
+ERROR: bootstrap checks failed max file descriptors [16384] for elasticsearch process is too low, increase to at least [65536]
+```
+Try to launch the container with these arguments:
+```bash
+docker run -p 9200:9200 --ulimit nofile=65536:65536 elasticsearch:5.4.1
+```
 
 ---
 

--- a/src/guide/essentials/cli.md
+++ b/src/guide/essentials/cli.md
@@ -18,11 +18,6 @@ Kuzzle ships with a [Command line interface](https://en.wikipedia.org/wiki/Comma
 * Clear Kuzzle cache
 * Diagnose the Kuzzle installation
 
-<aside class="warning">
-If you are running Kuzzle in a Docker container, you will have to execute these commands from within the <a href="https://docs.docker.com/engine/reference/commandline/exec/">running container</a>.
-<i>Example: docker-compose exec kuzzle ./bin/kuzzle start</i>
-</aside>
-
 The CLI is located in the `bin` folder of your Kuzzle installation.  
 If you have already created an admin, you will need to provide your login information to the CLI.  
 To get a list of commands and options run the CLI:
@@ -71,6 +66,7 @@ The `createFirstAdmin` command lets you create an administrator to manage securi
 <aside class="notice">NB: This command can only be run interactively</aside>
 
 This call the action [security#createFirstAdmin]({{ site_base_path }}api-documentation/controller-security/create-first-admin)
+
 ---
 
 ## clearCache
@@ -82,6 +78,7 @@ This call the action [security#createFirstAdmin]({{ site_base_path }}api-documen
 Kuzzle uses Redis to store frequently accessed internal data. Use this command if you need to clear this data (cache).
 
 This call the action [admin#resetCache]({{ site_base_path }}api-documentation/controller-admin/reset-cache)
+
 ---
 
 ## dump
@@ -109,6 +106,7 @@ The `dump` command creates a snapshot of the state of Kuzzle, including:
 The generated directory can be used to feed a crash report to the support team.
 
 This call the action [admin#dump]({{ site_base_path }}api-documentation/controller-admin/reset-security)
+
 ---
 
 ## reset
@@ -135,6 +133,7 @@ Asynchronously start the following sequence in Kuzzle, in this order:
 This action has no impact on Plugin and Document storage.
 
 This call the action [admin#resetKuzzleData]({{ site_base_path }}api-documentation/controller-admin/reset-kuzzle-data)
+
 ---
 
 ## resetSecurity
@@ -157,6 +156,7 @@ This call the action [admin#resetKuzzleData]({{ site_base_path }}api-documentati
 The `resetSecurity` command deletes all created users, profiles and roles and reset the default roles and profiles : `anonymous`, `admin` and `default`.
 
 This call the action [admin#resetSecurity]({{ site_base_path }}api-documentation/controller-admin/reset-security)
+
 ---
 
 ## resetDatabase
@@ -179,6 +179,7 @@ This call the action [admin#resetSecurity]({{ site_base_path }}api-documentation
 The `resetDatabase` delete all indexes created by users. This does not include Kuzzle's internal index.
 
 This call the action [admin#resetDatabase]({{ site_base_path }}api-documentation/controller-admin/reset-database)
+
 ---
 
 ## shutdown

--- a/src/guide/essentials/real-time.md
+++ b/src/guide/essentials/real-time.md
@@ -13,7 +13,7 @@ Kuzzle features highly customizable notifications thanks to its **real-time engi
 
 ## Introduction
 
-Imagine you are developing a collaborative TO-DO application like [this](http://kuzzle.io/demos-tutorials/real-time-collaborative-todo-list/) one. All the TO-DO items are persisted in Kuzzle (in a collection called `todos`) so, once clients start, they fetch every available TO-DO items via a simple document search.
+Imagine you are developing a collaborative TO-DO application like [this](https://github.com/kuzzleio/demo/tree/master/todolist) one. All the TO-DO items are persisted in Kuzzle (in a collection called `todos`) so, once clients start, they fetch every available TO-DO items via a simple document search.
 
 But imagine that one of the users (let's call her Ann), adds a new TO-DO item. In order for other users (let's call them Tom and Matt) to display these new item, they need to perform a new document search on the corresponding data collection. They will not see the new items until they refresh (or restart) their application.
 

--- a/src/partials/cta-buttons.html
+++ b/src/partials/cta-buttons.html
@@ -1,5 +1,5 @@
 
 <div class="cta-buttons">
-  <a href="http://kuzzle-backoffice.netlify.com/" target="_blank"><button>Admin Console</button></a>
+  <a href="http://console.kuzzle.io" target="_blank"><button>Admin Console</button></a>
   <a href="/guide/essentials/installing-kuzzle"><button>Install</button></a>
 </div>


### PR DESCRIPTION
## What does this PR do ?
According to @gillesfabre34 feedback : 
- Fix dead link in realtime guide.
- Update Admin Console URL from Netlify to our console.kuzzle.io
- Add informations about possible error on Elasticsearch launch in the 
Elasticsearch Cookbook.

### How should this be manually tested?
Check Netlify build: 

- Fix dead link in realtime guide. => Go [here](https://deploy-preview-510--kuzzle-documentation.netlify.com/guide/essentials/real-time#introduction) and click on the link tagged as "this"
- Update Admin Console URL from Netlify to our console.kuzzle.io => Click on "Admin Console" button
- Add informations about possible error on Elasticsearch launch in the 
Elasticsearch Cookbook. => [here](https://deploy-preview-510--kuzzle-documentation.netlify.com/elasticsearch-cookbook/installation/#launch-elasticsearch)
- @Aschen Requested changes, remove "warning block" and fix layout on [CLI guide](https://deploy-preview-510--kuzzle-documentation.netlify.com/guide/essentials/cli) 
