### PR TITLE
Fix language tabs

### DIFF
--- a/metalsmith-plugins/language-tab.js
+++ b/metalsmith-plugins/language-tab.js
@@ -12,7 +12,6 @@ const defaultLanguages = {
 module.exports = () => {
   return (files, metalsmith, done) => {
     setImmediate(done);
-
     for (const file in files) {
       if (!files.hasOwnProperty(file) || !file.endsWith('.html')) {
         continue;
@@ -28,8 +27,7 @@ module.exports = () => {
 
       if (typeof data['language-tab'] === 'object') {
         languagesHeaders = data['language-tab'];
-      }
-      else {
+      } else {
         languagesHeaders = defaultLanguages;
       }
 
@@ -37,7 +35,7 @@ module.exports = () => {
 
       let selector = '';
 
-      for (const key of whitelist) {
+      for (let key = 0; key < whitelist.length; key++) {
         if (key > 0) {
           selector += ', ';
         }
@@ -81,21 +79,20 @@ module.exports = () => {
           isFirst = true;
           $(element).addClass('language-first-tab');
         }
+
         $(element).addClass('language-tab-active');
       });
 
       const languageSelector = $('<div>');
       languageSelector.addClass('language-tab-selector');
 
-      for (const i in whitelist) {
-        if (whitelist.hasOwnProperty(i)) {
-          const wval = whitelist[i];
-          if (i === 0) { // activate first tab
-            languageSelector.append(`<a href="#" class="language-tab-active" data-language-name="${wval}">${languagesHeaders[wval]}</a>`);
-          }
-          else {
-            languageSelector.append(`<a href="#" data-language-name="${wval}">${languagesHeaders[wval]}</a>`);
-          }
+      for (let i = 0; i < whitelist.length; i++) {
+        const wval = whitelist[i];
+
+        if (i === 0) { // activate first tab
+          languageSelector.append(`<a href="#" class="language-tab-active" data-language-name="${wval}">${languagesHeaders[wval]}</a>`);
+        } else {
+          languageSelector.append(`<a href="#" data-language-name="${wval}">${languagesHeaders[wval]}</a>`);
         }
       }
 


### PR DESCRIPTION
## What does this PR do?

https://github.com/kuzzleio/documentation/pull/515 fixed eslint errors and, amongst them, replaced usages of `==` with `===`

This introduced a fun bug, occuring because `Object.keys(<array>)`  returns the list of indexes... in string format.

```javascript
> foo = ['bar', 'baz', 'qux']
[ 'bar', 'baz', 'qux' ]
> Object.keys(foo)
[ '0', '1', '2' ]
> Object.keys(foo)[0]
'0'
> Object.keys(foo)[0] == 0
true
> Object.keys(foo)[0] === 0
false
```


### How should this be manually tested?

Language tabs in pages such as https://docs.kuzzle.io/sdk-reference/security/update-user/ do not work. 
They do in the netlify preview
