### PR TITLE
[Fix] Typo in validateSpecifications HTTP sample

### DIFF
--- a/src/api-documentation/controller-collection/validate-specifications.md
+++ b/src/api-documentation/controller-collection/validate-specifications.md
@@ -43,8 +43,8 @@ title: validateSpecifications
 
 ```json
 {
-  "controller": "admin",
-  "action": "updateSpecifications",
+  "controller": "collection",
+  "action": "validateSpecifications",
 
   "body": {
     "myindex": {
@@ -66,8 +66,8 @@ title: validateSpecifications
   "error": null,
   "index": "<index>",
   "collection": "<collection>",
-  "action": "updateMapping",
-  "controller": "admin",
+  "action": "validateSpecifications",
+  "controller": "collection",
   "state": "done",
   "requestId": "<unique request identifier>",
   "result": {


### PR DESCRIPTION
## What does this PR do ?
In our documentation, there is an error in the validateSpecifications HTTP sample in collection controller.

### How should this be manually tested?
Compare [actual page](https://docs.kuzzle.io/api-documentation/controller-collection/validate-specifications) with the [new one](https://deploy-preview-520--kuzzle-documentation.netlify.com/api-documentation/controller-collection/validate-specifications)