### PR TITLE
KZL 290 - Add fixtures for securities in CLI

### DIFF
--- a/src/guide/essentials/cli.md
+++ b/src/guide/essentials/cli.md
@@ -155,7 +155,6 @@ This call the action [admin#resetKuzzleData]({{ site_base_path }}api-documentati
 
 The `resetSecurity` command deletes all created users, profiles and roles and reset the default roles and profiles : `anonymous`, `admin` and `default`.
 
-<<<<<<< HEAD
 This call the action [admin#resetSecurity]({{ site_base_path }}api-documentation/controller-admin/reset-security)
 
 ---
@@ -179,10 +178,9 @@ This call the action [admin#resetSecurity]({{ site_base_path }}api-documentation
 
 The `resetDatabase` delete all indexes created by users. This does not include Kuzzle's internal index.
 
-This call the action [admin#resetDatabase]({{ site_base_path }}api-documentation/controller-admin/reset-database)
-=======
+This call the action [admin#resetDatabase]({{ site_base_path }}api-documentation/controller-admin/reset-database)  
+
 Note: this command has no impact on any plugins stored data, or on any Kuzzle stored documents.
->>>>>>> 3022977... Add explanation about --fixtures for CLI start
 
 ---
 

--- a/src/guide/essentials/cli.md
+++ b/src/guide/essentials/cli.md
@@ -323,7 +323,7 @@ Read roles, profiles and users from a file and loads them into the storage layer
 
 The file must be a JSON file with the following structure:
 
-```js
+```json
 {
   "roles": {
     "role-id": {

--- a/src/guide/essentials/cli.md
+++ b/src/guide/essentials/cli.md
@@ -155,6 +155,7 @@ This call the action [admin#resetKuzzleData]({{ site_base_path }}api-documentati
 
 The `resetSecurity` command deletes all created users, profiles and roles and reset the default roles and profiles : `anonymous`, `admin` and `default`.
 
+<<<<<<< HEAD
 This call the action [admin#resetSecurity]({{ site_base_path }}api-documentation/controller-admin/reset-security)
 
 ---
@@ -179,6 +180,9 @@ This call the action [admin#resetSecurity]({{ site_base_path }}api-documentation
 The `resetDatabase` delete all indexes created by users. This does not include Kuzzle's internal index.
 
 This call the action [admin#resetDatabase]({{ site_base_path }}api-documentation/controller-admin/reset-database)
+=======
+Note: this command has no impact on any plugins stored data, or on any Kuzzle stored documents.
+>>>>>>> 3022977... Add explanation about --fixtures for CLI start
 
 ---
 
@@ -211,6 +215,8 @@ This call the action [admin#shutdown]({{ site_base_path }}api-documentation/cont
 #      -h, --help                 output usage information
 #          --fixtures <file>      import data from file
 #          --mappings <file>      apply mappings from file
+#          --securities <file>    import roles, profiles and users from file
+
 ```
 
 The `start` command starts a Kuzzle instance.
@@ -267,7 +273,7 @@ The input file must be a JSON file with the following structure:
 }
 ```
 
-### `--fixtures`
+#### `--fixtures`
 
 Reads documents from a file and loads them into the storage layer.
 
@@ -308,5 +314,107 @@ The file must be a JSON file with the following structure:
       {"bar": "baz", "qux": ["q", "u", "x"]}
     ]
   }
+}
+```
+
+#### `--securities`
+
+Read roles, profiles and users from a file and loads them into the storage layer.
+
+The file must be a JSON file with the following structure:
+
+```js
+{
+  "roles": {
+    "role-id": {
+      /* role definition */
+    }
+  },
+  "profiles": {
+    "profile-id": {
+      /* profile definition */
+    }
+  },
+  "users": {
+    "user-id": {
+      /* user definition */
+    }
+  }
+}
+```
+
+The roles, profiles and users definition follow the same structure as in the body parameter of the API:
+ - [createRole](https://docs.kuzzle.io/api-documentation/controller-security/create-role)
+ - [createProfile](https://docs.kuzzle.io/api-documentation/controller-security/create-profile)
+ - [createUser](https://docs.kuzzle.io/api-documentation/controller-security/create-user)
+
+**Notes:**
+
+* The file can contain any number of roles, profiles and users.
+* If a role, profile or user already exists, it will be replaced.
+* Fixtures are loaded sequentially, first the roles, then the profiles and finally the users. If a failure occurs, Kuzzle immediately interrupts the sequence.
+
+**Example:**
+
+```json
+{
+	"roles": {
+		"role-id-1": {
+			"controllers": {
+				"*": {
+					"actions": {
+						"*": true
+					}
+				}
+			},
+			"role-id-2": {
+				"controllers": {
+					"*": {
+						"actions": {
+							"*": true
+						}
+					}
+				}
+			}
+		},
+		"profiles": {
+			"profile-id-1": {
+				"policies": [{
+					"roleId": "role-id-1",
+					"restrictedTo": []
+				}]
+			},
+			"profile-id-2": {
+				"policies": [{
+					"roleId": "role-id-2",
+					"restrictedTo": []
+				}]
+			}
+		},
+		"users": {
+			"user-id-1": {
+				"content": {
+					"profileIds": ["profile-id-1"]
+				},
+				"credentials": {
+					"local": {
+						"username": "nina",
+						"password": "thug"
+					}
+				}
+			},
+			"user-id-2": {
+				"content": {
+					"profileIds": ["profile-id-2"]
+				},
+				"credentials": {
+					"local": {
+						"username": "alyx",
+						"password": "vance"
+					}
+				}
+			}
+		}
+	}
 }
 ```


### PR DESCRIPTION
## What does this PR do ?

This PR add explanation about the ability to specify securities fixtures for the roles, users and profiles.  
These securities fixtures will be loaded into the storage layer at Kuzzle startup like mappings and database fixtures

(document following PR: https://github.com/kuzzleio/kuzzle/pull/1182)

### How should this be manually tested?

  - Step 1 : https://deploy-preview-521--kuzzle-documentation.netlify.com/guide/essentials/cli#securities
