### PR TITLE
KZL 454 - Deprecate pending notifications

### DIFF
--- a/src/api-documentation/notifications/document-creating.md
+++ b/src/api-documentation/notifications/document-creating.md
@@ -1,11 +1,13 @@
 ---
 layout: full.html.hbs
 algolia: true
-title: On Document Creation Pending 
+title: On Document Creation Pending
 order: 200
 ---
 
-# On Document Creation Pending 
+# On Document Creation Pending
+
+{{{deprecated "1.5.0"}}}
 
 Notification received when a document is about to be created:
 

--- a/src/api-documentation/notifications/document-deleting.md
+++ b/src/api-documentation/notifications/document-deleting.md
@@ -1,11 +1,13 @@
 ---
 layout: full.html.hbs
 algolia: true
-title: On Document Deletion Pending 
+title: On Document Deletion Pending
 order: 400
 ---
 
-# On Document Deletion Pending 
+# On Document Deletion Pending
+
+{{{deprecated "1.5.0"}}}
 
 Notification received when a document is about to be deleted:
 

--- a/src/api-documentation/notifications/index.md
+++ b/src/api-documentation/notifications/index.md
@@ -19,9 +19,9 @@ Document notifications can be sent to subscribers:
 
 * When a real-time message is sent
 * On Document Creation: a document has been successfully created
-* On Document Creation Pending: a document is about to be created (the creation is not guaranteed)
+* On Document Creation Pending: a document is about to be created (the creation is not guaranteed) {{{deprecated "1.5.0"}}}
 * On Document Deletion: A document has been deleted
-* On Document Deletion Pending: A document is about to be deleted (the deletion is not guaranteed)
+* On Document Deletion Pending: A document is about to be deleted (the deletion is not guaranteed) {{{deprecated "1.5.0"}}}
 * On Document Entering Subscription Scope: a document has been updated and enters the subscription scope
 * On Document Exiting Subscription Scope: a document has been updated and exits the subscription scope
 
@@ -39,7 +39,7 @@ A document notification contains the following fields:
 | `result._source` | object | The message or full document content. Undefined if the notification is about a document deletion |
 | `result._source._kuzzle_info` | object | Document meta-data (creation time, last update time, and so on). Can be null. |
 | `scope` | string | Indicates if the document enters or exits the subscription scope | `in`, `out` |
-| `state` | string | Shows if the document is about to be changed, or if the change is done | `pending`, `done` |
+| `state` | string | {{{deprecated "1.5.0"}}} Shows if the document is about to be changed, or if the change is done | `pending`, `done` |
 |`timestamp` | number | Timestamp of the request from which is issued this notification (in epoch-milliseconds) | |
 | `type` | string | The notification type | `document` |
 | `volatile` | object | Request [volatile data]({{ site_base_path }}api-documentation/volatile-data/) | |

--- a/src/sdk-reference/essentials/notifications.md
+++ b/src/sdk-reference/essentials/notifications.md
@@ -17,7 +17,7 @@ To subscribe, you must provide a callback that will be called each time a new no
 Once you have subscribed, depending on the subscription configuration you provided, you may receive a notification when:
 
 * a pub/sub message matches your criteria (real-time)
-* a matching document is about to be created or deleted in real-time (deactivated by default)
+* a matching document is about to be created or deleted in real-time (deactivated by default) {{{deprecated "1.5.0"}}}
 * a matching document is created, updated or deleted (once the change is effective in the database)
 * a user enters or leaves the room (deactivated by default)
 
@@ -85,13 +85,6 @@ room = collection.room(
   {state: 'all', scope: 'in', users: 'all', subscribeToSelf: false}
 );
 
-// listen to notifications about pending new documents:
-room.on('document', function(data) {
-  if (data.state === 'pending') {
-    console.log('A new document is about to enter the scope: ', data.document);
-  }
-});
-
 // listen to notifications about new documents:
 room.on('document', function(data) {
   if (data.state === 'done') {
@@ -131,7 +124,7 @@ room.subscribe(function(err, res) {
 |--------------------|------|------------------|-----------------|
 | `document` | [Document]({{ site_base_path }}sdk-reference/document/) | Content of the document or real-time message that generated the notification | |
 | `scope` | string | Indicates if the document enters or exits the subscription scope | `in`, `out` |
-| `state` | string | Shows if the document is about to be changed, or if the change is done | `pending`, `done` |
+| `state` | string | {{{deprecated "1.5.0"}}} Shows if the document is about to be changed, or if the change is done | `pending`, `done` |
 | `type` | string | Notification type | `document` |
 
 #### Example


### PR DESCRIPTION
## What does this PR do ?

This PR deprecate the usage of the `pending` notification before a document is updated/created/deleted.  
These notifications will be removed in Kuzzle v2.  
I have assumed that https://github.com/kuzzleio/kuzzle/pull/1185 will be released with Kuzzle `1.5.0`.

### How should this be manually tested?

  - Step 1 :