### PR TITLE
Add since tag for mapping in collection create

### DIFF
--- a/src/api-documentation/controller-collection/create.md
+++ b/src/api-documentation/controller-collection/create.md
@@ -89,8 +89,10 @@ title: create
   }
 }
 ```
-
 Creates a new [collection]({{ site_base_path }}guide/essentials/persisted) in Kuzzle via the persistence engine, in the provided `index`.  
+
+{{{since "1.3.0"}}}
+
 You can also provide an optional body with a data mapping that allow you to exploit the full capabilities of our
 persistent data storage layer, [ElasticSearch](https://www.elastic.co/products/elasticsearch) (check here the [mapping capabilities of ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/mapping.html)).  
 

--- a/src/sdk-reference/collection/create.md
+++ b/src/sdk-reference/collection/create.md
@@ -11,7 +11,7 @@ title: create
 # create
 
 ```js
-// Optional: a mapping can be provided and will be 
+// Optional: a mapping can be provided and will be
 // applied when the collection is created
 const mapping = {
   properties: {
@@ -49,7 +49,7 @@ kuzzle
 ```
 
 ```java
-// Optional: a mapping can be provided and will be 
+// Optional: a mapping can be provided and will be
 // applied when the collection is created
 JSONObject mapping = new JSONObject()
   .put("properties", new JSONObject()
@@ -84,7 +84,7 @@ use \Kuzzle\Kuzzle;
 $kuzzle = new Kuzzle('localhost');
 $dataCollection = $kuzzle->collection('collection', 'index');
 
-// Optional: a mapping can be provided and will be 
+// Optional: a mapping can be provided and will be
 // applied when the collection is created
 $mapping = [
   'properties' => [
@@ -124,6 +124,9 @@ catch (ErrorException $e) {
 ```
 
 Creates a new [collection]({{ site_base_path }}guide/essentials/persisted) in Kuzzle via the persistence engine, in the provided `index`.  
+
+{{{since "1.3.0"}}}
+
 You can also provide an optional data mapping that allow you to exploit the full capabilities of our
 persistent data storage layer, [ElasticSearch](https://www.elastic.co/products/elasticsearch) (check here the [mapping capabilities of ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/mapping.html)).  
 


### PR DESCRIPTION
## What does this PR do ?

This PR add a `since` tag to the api and sdk documentation for collection create because we can specify a mapping since Kuzzle 1.3.0 only (https://github.com/kuzzleio/kuzzle/releases/tag/1.3.0)
