### PR TITLE
Koncorde: new array value syntax documentation

### DIFF
--- a/src/kuzzle-dsl/essential/arrayvalues.md
+++ b/src/kuzzle-dsl/essential/arrayvalues.md
@@ -10,7 +10,7 @@ order: 25
 
 A few keywords, like [exists]({{ site_base_path }}kuzzle-dsl/terms/exists) or [missing]({{ site_base_path }}kuzzle-dsl/terms/missing), allow searching for array values.
 
-These values can be accessed with the following syntax: `arrayName['value']`  
+These values can be accessed with the following syntax: `<array path>[<value>]`  
 Only one array value per `exists`/`missing` keyword can be searched in this manner.
 
 Array values must be scalars: strings, numbers, booleans or the `null` value.

--- a/src/kuzzle-dsl/essential/arrayvalues.md
+++ b/src/kuzzle-dsl/essential/arrayvalues.md
@@ -1,0 +1,46 @@
+---
+layout: full.html.hbs
+algolia: true
+title: Matching array values
+description: How to test array values
+order: 25
+---
+
+# Matching array values
+
+A few keywords, like [exists]({{ site_base_path }}kuzzle-dsl/terms/exists) or [missing]({{ site_base_path }}kuzzle-dsl/terms/missing), allow searching for array values.
+
+These values can be accessed with the following syntax: `arrayName['value']`  
+Only one array value per `exists`/`missing` keyword can be searched in this manner.
+
+Array values must be scalars: strings, numbers, booleans or the `null` value.
+
+The array value must be provided using the JSON format:
+
+* Strings: the value must be enclosed in double quotes. Example: `foo["string value"]`
+* Numbers, booleans and `null` must be used as is. Examples: `foo[3.14]`, `foo[false]`, `foo[null]`
+
+
+Array values can be combined with [nested properties]({{ site_base_path }}kuzzle-dsl/essential/nested): `nested.array["value"]`
+
+# Example
+
+Given the following document:
+
+```json
+{
+    "name": {
+        "first": "Grace",
+        "last": "Hopper",
+        "hobbies": ["compiler", "COBOL"]
+    }
+}
+```
+
+Here is a filter, testing whether the value `compiler` is listed in the array `hobbies`:
+
+```json
+{
+    "exists": "name.hobbies[\"compiler\"]"
+}
+```

--- a/src/kuzzle-dsl/essential/geodistances.md
+++ b/src/kuzzle-dsl/essential/geodistances.md
@@ -24,7 +24,7 @@ Accepted unit modifiers: from `yocto-` (10e-21) to `yotta-` (10e24), and their c
 
 Accepted formats: `<int (spaces accepted)>[.|,]<decimals><spaces><unit>`.  
 
-**Example**
+# Example
 
 The following distances are all equivalent and valid input parameters:
 

--- a/src/kuzzle-dsl/essential/nested.md
+++ b/src/kuzzle-dsl/essential/nested.md
@@ -12,7 +12,7 @@ Examples described in this documentation show how to test for fields at the root
 
 To do that, instead of giving the name of the property to test, its path must be supplied as follows: `path.to.property`
 
-**Example:**
+# Example
 
 Given the following document:
 

--- a/src/kuzzle-dsl/terms/equals.md
+++ b/src/kuzzle-dsl/terms/equals.md
@@ -8,7 +8,16 @@ title: equals
 
 {{{since "1.0.0"}}}
 
-The `equals` filter matches documents or messages attributes using string equality.
+Matches attributes using strict equality.  
+The tested attribute must be a scalar (number, string or boolean), and of the same type than the provided filter value.
+
+## Syntax
+
+```
+equals: {
+  <field name>: <value>
+}
+```
 
 ## Example
 

--- a/src/kuzzle-dsl/terms/exists.md
+++ b/src/kuzzle-dsl/terms/exists.md
@@ -8,7 +8,21 @@ title: exists
 
 {{{since "1.0.0"}}}
 
-The `exists` filter matches documents containing non-null fields.
+Test for the existence of a key in an object, or of a scalar in an array.  
+
+## Syntax
+
+Since Koncorde 1.2, the `exists` syntax is as follows:
+
+`exists: 'nested.field.path'`
+(see [nested field syntax]({{ site_base_path }}kuzzle-dsl/essential/nested))
+
+`exists: 'nested.array[value]'`
+(see [array value syntax])({{ site_base_path }}kuzzle-dsl/essential/arrayvalues)
+
+The following syntax is deprecated since Koncorde 1.2, and supported for backward compatibility only:
+
+`exists: { field: 'nested.field.path' }`
 
 ## Example
 
@@ -19,14 +33,14 @@ Given the following documents:
   firstName: 'Grace',
   lastName: 'Hopper',
   city: 'NYC',
-  hobby: 'computer',
+  hobby: ['compiler', 'COBOL'],
   alive: false
 },
 {
   firstName: 'Ada',
   lastName: 'Lovelace',
   city: 'London',
-  hobby: 'computer'
+  hobby: ['programming', 'algorithm']
 }
 ```
 
@@ -34,8 +48,14 @@ The following filter validates the first document:
 
 ```javascript
 {
-  exists: {
-    field: 'alive'
-  }
+  exists: 'alive'
+}
+```
+
+And this filter validates the second document:
+
+```javascript
+{
+  exists: 'hobby["algorithm"]'
 }
 ```

--- a/src/kuzzle-dsl/terms/exists.md
+++ b/src/kuzzle-dsl/terms/exists.md
@@ -18,7 +18,7 @@ Since Koncorde 1.2, the `exists` syntax is as follows:
 (see [nested field syntax]({{ site_base_path }}kuzzle-dsl/essential/nested))
 
 `exists: 'nested.array[value]'`
-(see [array value syntax])({{ site_base_path }}kuzzle-dsl/essential/arrayvalues)
+(see [array value syntax])({{ site_base_path }}kuzzle-dsl/essential/arrayvalues))
 
 The following syntax is deprecated since Koncorde 1.2, and supported for backward compatibility only:
 

--- a/src/kuzzle-dsl/terms/geo-bounding-box.md
+++ b/src/kuzzle-dsl/terms/geo-bounding-box.md
@@ -19,9 +19,19 @@ A bounding box is a 2D box that can be defined using either of the following for
 
 The bounding box description must be stored in an attribute, named after the geographical point to be tested in future documents.
 
-## Format examples
+## Syntax
 
-All of the following filter examples test for a geographical point named `point`, whose coordinates should be in a bounding box with the following properties:
+```
+geoBoundingBox: { 
+  <geopoint field name>: {
+    <bounding box description>
+  } 
+}
+```
+
+## Bounding box description
+
+All of the following syntaxes below are accepted, and they describe the same bounding box, with the following properties:
 
 * top-left corner of latitude `43.5810609` and longitude `3.8433703`
 * bottom-right corner of latitude `43.6331979` and longitude `3.9282093`

--- a/src/kuzzle-dsl/terms/geo-bounding-box.md
+++ b/src/kuzzle-dsl/terms/geo-bounding-box.md
@@ -31,7 +31,7 @@ geoBoundingBox: {
 
 ## Bounding box description
 
-All of the following syntaxes below are accepted, and they describe the same bounding box, with the following properties:
+All syntaxes below are accepted, as they describe the same bounding box, with the following properties:
 
 * top-left corner of latitude `43.5810609` and longitude `3.8433703`
 * bottom-right corner of latitude `43.6331979` and longitude `3.9282093`

--- a/src/kuzzle-dsl/terms/geo-distance-range.md
+++ b/src/kuzzle-dsl/terms/geo-distance-range.md
@@ -18,6 +18,18 @@ A `geoDistanceRange` filter contains the following properties:
 * a `from` attribute, describing the minimum distance from the center point, using a [geodistance format]({{ site_base_path }}kuzzle-dsl/essential/geodistances/)
 * a `to` attribute, describing the maximum distance from the center point, using a [geodistance format]({{ site_base_path }}kuzzle-dsl/essential/geodistances/)
 
+## Syntax
+
+```
+geoDistanceRange: {
+  <geopoint field name>: {
+    <geopoint description>
+  },
+  from: <geodistance>,
+  to: <geodistance>
+}
+```
+
 ## Example
 
 Given the following documents:

--- a/src/kuzzle-dsl/terms/geo-distance.md
+++ b/src/kuzzle-dsl/terms/geo-distance.md
@@ -17,6 +17,16 @@ A `geoDistance` filter contains the following properties:
 * a [geopoint]({{ site_base_path }}kuzzle-dsl/essential/geopoints/) defining the point of origin. This geopoint attribute must be named after the geographical point to test in future documents
 * a `distance` parameter in [geodistance format]({{ site_base_path }}kuzzle-dsl/essential/geodistances/)
 
+## Syntax
+
+```
+geoDistance: {
+  <geopoint field name>: {
+    <geopoint description>
+  },
+  distance: <geodistance>
+}
+```
 
 ## Example
 

--- a/src/kuzzle-dsl/terms/geo-polygon.md
+++ b/src/kuzzle-dsl/terms/geo-polygon.md
@@ -13,12 +13,20 @@ Filter documents containing a geographical point, confined within a polygon that
 ![Illustration of geoPolygon]({{ site_base_path }}assets/images/geolocation/geoPolygon.png)
 
 A `geoPolygon` filter is described using a `points` array, containing an arbitrary number of [geopoints]({{ site_base_path }}kuzzle-dsl/essential/geopoints/) (at least 3).  
+
 Koncorde automatically closes geopolygons.
 
 Different geopoint formats can be used to describe different corners of a polygon.
 
-The `points` object must be stored in an attribute named after the geographical point to test in future documents.
+## Syntax
 
+```
+geoPolygon: {
+  <geopoint field name>: {
+    points: <geopoints array>
+  }
+}
+```
 
 ## Example
 

--- a/src/kuzzle-dsl/terms/ids.md
+++ b/src/kuzzle-dsl/terms/ids.md
@@ -8,7 +8,11 @@ title: ids
 
 {{{since "1.0.0"}}}
 
-This filter returns documents that have an ID that matches the input list.
+This filter returns only documents having their unique document ID listed in the provided list.
+
+## Syntax
+
+`ids: <array of strings>`
 
 ## Example
 

--- a/src/kuzzle-dsl/terms/in.md
+++ b/src/kuzzle-dsl/terms/in.md
@@ -8,7 +8,11 @@ title: in
 
 {{{since "1.0.0"}}}
 
-This filter can be used to match a field to one of many values.
+Like [equals]({{ site_base_path }}kuzzle-dsl/terms/equals), but accepts an array of possible scalar values to be tested.
+
+## Syntax
+
+`in: { <field name>: <array of values> }`
 
 ## Example
 

--- a/src/kuzzle-dsl/terms/missing.md
+++ b/src/kuzzle-dsl/terms/missing.md
@@ -8,7 +8,26 @@ title: missing
 
 {{{since "1.0.0"}}}
 
-A filter matching documents with a missing field.
+A filter matching documents either with a missing field in an object, or with a missing value in an array.
+
+A `missing` filter used to match arrays without a specific value will also match if:
+
+* the tested array property is entirely missing from the provided document
+* the tested property in the provided document is not an array
+
+## Syntax
+
+Since Koncorde 1.2, the `missing` syntax is as follows:
+
+`missing: 'nested.field.path'`
+(see [nested field syntax]({{ site_base_path }}kuzzle-dsl/essential/nested))
+
+`missing: 'nested.array[value]'`
+(see [array value syntax])({{ site_base_path }}kuzzle-dsl/essential/arrayvalues)
+
+The following syntax is deprecated since Koncorde 1.2, and supported for backward compatibility only:
+
+`missing: { field: 'nested.field.path' }`
 
 ## Example
 
@@ -19,14 +38,14 @@ Given the following documents:
   firstName: 'Grace',
   lastName: 'Hopper',
   city: 'NYC',
-  hobby: 'computer',
+  hobbies: ['compiler', 'COBOL'],
   alive: false
 },
 {
   firstName: 'Ada',
   lastName: 'Lovelace',
   city: 'London',
-  hobby: 'computer',
+  hobbies: ['algorithm', 'programming'],
 }
 ```
 
@@ -34,8 +53,14 @@ The following filter validates the second document:
 
 ```javascript
 {
-  missing: {
-    field: 'alive'
-  }
+  missing: 'alive'
+}
+```
+
+And this filter validates the first document: 
+
+```javascript
+{
+  missing: 'hobbies["algorithm"]'
 }
 ```

--- a/src/kuzzle-dsl/terms/range.md
+++ b/src/kuzzle-dsl/terms/range.md
@@ -8,17 +8,29 @@ title: range
 
 {{{since "1.0.0"}}}
 
-Filters documents with fields having number attributes within a certain range.
+Filters documents with number attributes within a provided interval.
 
-The range filter accepts the following parameters:
+A range can be defined with at least one of the following arguments:
 
-`gte` Greater-than or equal to
+* `gte`: Greater-than or equal to `<number>`
+* `gt`: Greater-than `<number>`
+* `lte`: Less-than or equal to
+* `lt`: Less-than
 
-`gt` Greater-than
+Ranges can be either bounded or half-bounded.
 
-`lte` Less-than or equal to
+## Syntax 
 
-`lt` Less-than
+```
+range: {
+  <field to be tested>: {
+    [gte]: <number>,
+    [gt]: <number>,
+    [lte]: <number>,
+    [lt]: <number>
+  }
+}
+```
 
 ## Example
 
@@ -54,7 +66,6 @@ The following filter validates the last two documents:
 {
   range: {
     age: {
-      gte: 36,
       lt: 85
     }
   }

--- a/src/kuzzle-dsl/terms/regexp.md
+++ b/src/kuzzle-dsl/terms/regexp.md
@@ -7,31 +7,27 @@ title: regexp
 # regexp
 
 {{{since "1.0.0"}}}
+The `regexp` filter matches attributes using [PCREs](https://en.wikipedia.org/wiki/Perl_Compatible_Regular_Expressions).
 
-The `regexp` filter matches documents or messages using perl-compatible regular expressions ([PCRE](https://en.wikipedia.org/wiki/Perl_Compatible_Regular_Expressions)).  
-You can only test 1 attribute per `regexp` filter.
+## Syntax
 
 A `regexp` filter has the following structure, splitting the usual `/pattern/flags` into two parts:
 
 ```javascript
-{
-  regexp: {
-    attributeToTest: {
-      value: 'search pattern',
-      flags: 'modifier flags'
-    }
+regexp: {
+  <field name>: {
+    value: '<search pattern>',
+    flags: '<modifier flags>'
   }
 }
 ```
 
-Or, if you don't want to add any modifier flags:
+If you don't need any modifier flag, then you may also use the following simplified form:
 
 ```javascript
-{
   regexp: {
-    attributeToTest: 'search pattern'
+    <field name>: '<search pattern>'
   }
-}
 ```
 
 ## Example


### PR DESCRIPTION
## What does this PR do?

* Documents the new array value syntax in Koncorde
* Documents the new `exists`/`missing` keywords formats

### Other changes

* Add a new `Syntax` section to all Koncorde terms description, providing an easy to read overview
* Reworded some keywords descriptions to make them clearer
