### PR TITLE
fix resetCache URL

### DIFF
--- a/src/api-documentation/controller-admin/reset-cache.md
+++ b/src/api-documentation/controller-admin/reset-cache.md
@@ -14,7 +14,7 @@ title: resetCache
 
 <blockquote class="js">
 <p>
-**URL:** `http://kuzzle:7512/admin/_resetCache`  
+**URL:** `http://kuzzle:7512/admin/_resetCache?database=[internalCache|memoryStorage]`  
 **Method:** `POST`
 </p>
 </blockquote>

--- a/src/api-documentation/controller-admin/reset-cache.md
+++ b/src/api-documentation/controller-admin/reset-cache.md
@@ -52,6 +52,7 @@ title: resetCache
 
 Asynchronously clear Redis database used by Kuzzle.  
 
-There are two Redis databases that you can clear :
+There are two Redis databases that you can clear:
+
  - `internalCache` : used by Kuzzle to cache internal data, such as authentication tokens, documents followed by real-time subscriptions, active paginated search queries, API usage statistics or cluster state
  - `memoryStorage` : memory cache managed by Kuzzle's [memoryStorage]({{ site_base_path }}api-documentation/controller-memory-storage/) API


### PR DESCRIPTION
# Description

The `database` argument is required, yet missing from the URL documentation of the `admin:resetCache` API route