### PR TITLE
Fix bulk return

### DIFF
--- a/src/api-documentation/controller-bulk/import.md
+++ b/src/api-documentation/controller-bulk/import.md
@@ -78,7 +78,7 @@ title: import
   "requestId": "<unique request identifier>",
   "result": {
     // The list of executed queries, with their status
-    "hits": [
+    "items": [
       {
         "create": {
           "_id": "<documentId>",
@@ -175,7 +175,7 @@ If a subset of the documents fail to save, the client will receive a <a href="{{
   "requestId": "<unique request identifier>",
   "result": {
     // The list of executed queries, with their status
-    "hits": [
+    "items": [
       {
         "create": {
           "_id": "<documentId>",


### PR DESCRIPTION

## What does this PR do ?

Bulk import method return an object containing the import result in the `items` property and not `hits`