### PR TITLE
Fix realtime publish return

### DIFF
--- a/src/api-documentation/controller-realtime/publish.md
+++ b/src/api-documentation/controller-realtime/publish.md
@@ -63,11 +63,7 @@ title: publish
   "volatile": {},
   "requestId": "<unique request identifier>",
   "result": {
-    "hello": "world",
-    "_kuzzle_info": {
-      "createdAt": 1534775616139
-      "author": "-1"
-    }
+    "published": true
   }
 }
 ```


### PR DESCRIPTION
## What does this PR do ?

Realtime:publish return a json containing `{"published": <boolean>}` and not the document

### How should this be manually tested?

  - Step 1 : `curl -X POST kuzzle:7512/test-idx/test-col/_publish?pretty -H "Content-Type:application/json" --data '{"toto": 42}'`
