### PR TITLE
Deprecate 3 realtime methods

### DIFF
--- a/src/api-documentation/controller-realtime/join.md
+++ b/src/api-documentation/controller-realtime/join.md
@@ -12,6 +12,7 @@ title: join
 
 {{{since "1.0.0"}}}
 
+{{{deprecated "1.5.0"}}}
 
 
 <blockquote class="json">

--- a/src/api-documentation/controller-realtime/join.md
+++ b/src/api-documentation/controller-realtime/join.md
@@ -12,7 +12,6 @@ title: join
 
 {{{since "1.0.0"}}}
 
-{{{deprecated "1.5.0"}}}
 
 
 <blockquote class="json">

--- a/src/api-documentation/controller-realtime/list.md
+++ b/src/api-documentation/controller-realtime/list.md
@@ -12,6 +12,7 @@ title: list
 
 {{{since "1.0.0"}}}
 
+{{{deprecated "1.5.0"}}}
 
 <blockquote class="js">
 <p>

--- a/src/api-documentation/controller-realtime/validate.md
+++ b/src/api-documentation/controller-realtime/validate.md
@@ -11,6 +11,8 @@ title: validate
 
 {{{since "1.0.0"}}}
 
+{{{deprecated "1.5.0"}}}
+
 
 <blockquote class="js">
 <p>
@@ -63,7 +65,7 @@ title: validate
 }
 ```
 
-Validates data against existing validation rules. 
+Validates data against existing validation rules.
 
 If the document is valid, the `result.valid` value is `true`, if not, it is `false`.
 If the document is not valid, the `result.errorMessages` will contain detailed hints on what is wrong with the document.


### PR DESCRIPTION
## What does this PR do ?

The following are deprecated and will be removed in Kuzzle v2:
 - `realtime:list` : useless method
 - `realtime:validate` : duplicate with `document:validate`