### PR TITLE
[ci] Use script provider for s3 --delete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,49 @@
-sudo: false
+sudo: required
 language: node_js
+
+services:
+  - docker
+
 node_js:
-- '6'
+  - '8'
+
 env:
   global:
-  - secure: g65DksnY5ZjIS7lHeOGH1PxtJS7VFnqjQbK7N4J1CSU5osW8IqWy4iENkgzHCCgg0fT0ea4IL+Fbxk7RMnKixt7x0ULYa3+6HqM7Z1l7PBHF0qjfUlEPZBrW6yUzEuJb4OEQPD5hL2ZmTZua+yEnASKmWE+aorohrnzcTlWYMCr1/6+IOLTLAhZjQLpI4wjcJbJ46hRAfKwMjZshdmIcIILV34zAb/5RgBQSlmJdfjEIv6vsPL4kWHUgqwp+AsgeWKwsMlBKBkp1rYZJr9iGvdJibWsvKLs8jU9oaFVpBg9wGmBk4Ms5ajInP5rKYWQK+fQNfaXyoKDXd30YSoyNaWORfjhiYc8+FHvKLkoYm+8CiTuX8hgC0v4A4IicsihnWB/N35BwVOdZNsHF2WrEpqbRK7sBQ4whdoncFRjNhB7uFYSy2LQtAb+31wb1lUk5nPO6pEweCsp3CrmIHfjDbU87s6p9IGm3QDTp9rhwPibP2RijgJwY9xV+CzAT3fVoIDRPn588ixCXWBHx7UQYqhtdPaBXCSANDJAnH+ndL9M4WlMigna2e16r1KkLkrVlFoCmcdLM2KSDAb9C3OE+EZRURxPGTGzxWFXQ89FHky2hVRuUEYwtWmXzRtoHoxhoNqareW32ezkmJGQZXiVBM2wghFN6iPRxB5KLTBSnX18=
-  - secure: qREG2WSpabHFuvw0IdCNnIwnCRYe9URxIaTOgAw5a5yCItjikSpXYNp5AZAC8TwIA9xh1Xb59r2RU+MLBazo70K5BU8Sdc+k2R1dV9+QxPPuziC/sJch6tgmJl/6BhjnmMKqIsWEsGpXTe1I0/hk2Uu4/JqZlK0KYxrPxzcox90sEDP4lathYPOAXjc5TTELgAIeHxGziI47UPXPjogDRksIc0A9ZBuWb+Ajc470Qn4M9wtg7Tm2xB9H79mlSVzduF5TpPK3q395Krg4/h0gjYgbOk8Nekd9Lqrm0a9dUWC4LwSBUm07obxZr7HabGh7lVqcCsljqUSc+5lBuca+K2os6njvqFPnfyT8E/ZyZDVydT33+wDI0nU5+ZgskMt0NIvRwqWUy7Au96VVCaQa5jVPS14DOIF3vBbT5vnkw50iCeg7HmW/lowoqpJqKlVuJJGufKAIGvcJbeEms8PCxq9j2TjXikmid8fCuOipH9tIckjwS2XtfswPySIJoH1d9Sdtqbm/ABB9cH8No8xx0Gj6uUQKFkl0/7lcWx4vmBIW78GyYKrqVYhyd9W00QFLg9spzBmw3/REch6Kj45YzrAYd6+AQNfIQ/H30Vu43bpUdLnuqt3FVSq+LxyAcKK7R72qy5NgrUz/y0ALU1o+Kbe+WDaRiFGzAvOQBKlO/Gs=
-  - secure: bDH0GRG+D/3vjpgqtTeYjiH0avtSLgvtx9gIFyB9EIwpIjkmz7Bi1vWfzYM1kQmcL8Nd2SpXKPJjniV3/N22Wl6adHigF8v8IbaFwbzhb1pja/5iqqj3UHuYt8dfYWWJYPONzA1SRmn0lQ/mYT0xxtmeNygCP6l7vZ3WQ/Fc15hdGafKtFg9Cqdek27r8oMMgPUrplXEIOxFjm59BcxRR6SCq4Yk6Amdfkktr9wLeO4i5ghFcm/Wt5xlY73kpEiwelQNPaXERedz5x7kDq/sGU+UIKGbDXuSa8ujmzwiK/Igp5ZHT3E1SCExgaHnVMYJY2VMbgHqx79Mew/G8a/c+OnQ9A7AlWWhB9MA0/75qUMeiQENi5rqXU2n2AvB8uBNkQYmxISmUPTYYLGyHXLmWbstnd8KyAE62/hh7WxHMHGD4BNFmPs68QMoeAHwIOoyGX4TfAZvhPV3XjaHlX21pHqEP1PdrCORWXeDA/tFZnnKS8dE2iA6sR2wAY/5yA7nVLKChrvS6ZaOFrRIIyl3KldeJV+0YntK0HRI0da2lnrlv2rVE77ysZ+vf4fRTOfLpQ/ToUqz7HI5UZjKseVLdVjLDTApc2FZJ2443DryqDWD0aNSEgikKulVxc0lGQTxgAHTJ2kZHTzstfn5MnDx1bGMBtVVxykviZvbq8SNOe8=
-  - secure: Mce3HSenklbG1jCxZyuERn/tecMqxhAV42UlQ+6P4gqwxOEVyr4j89AeTrKBnu2Y4nBRd8VdM0y5Y1QH5iK8bZ+IPCWjvWzHz+t+QQ5q5saJfZvRVesgL/P04+CXiK6Z7dEnjmE8zohSGntAIqq02iwgX/DM+Bhk03PXDgoKwQkhOF3gB4BjXaL94shreg1uGNhYpuApZRxBfkZt+rzRdOiCAAlbhsHOxJcluZVAMNo3U9Y1Rbh8dhei8ENqsY+9R7bstRfpKbflMU0W/PxnRjeWWUL8MCTKx4wjoFXd16rsi75hIXe4j/8L0CLraOiGc8DxROK9C3XPFblKIiKaeBj19EhLLJZoTINxoyIYYlrHGdvrmZ8MDPJhUSUH6kid2PoHzod8/9ddM8fbn1xO8+NJ18gqnEZuPDHJa+6oR/y2fb01mZTWyVyc2giNpzCLgCcj1kCLTqXpoEVr6Eb7Bi6lLHUh5f7eeR0HwsCoBVTtyy2SOhgBR2hGuZMGnE18V6s58yDi65RENGr4/YI5D1sYMRRoQgvPv7XG005PyNZHoWsnRopoDSPDHF2bvYvgNrET2HfRihoLZxMmN3L0HNHrYlb4g+qMnwexz7r2uUwflDsV0851mg1BYwBSB6U6eamU28HDunDjvsphpfGtwZZY51E0KTCasBD0X3KkDbo=
-  - CLOUDFRONT_DISTRIBUTION_ID=E3D6RP0POLCJMM
-  - BUCKET_NAME=docs.kuzzle.io
+    - secure: g65DksnY5ZjIS7lHeOGH1PxtJS7VFnqjQbK7N4J1CSU5osW8IqWy4iENkgzHCCgg0fT0ea4IL+Fbxk7RMnKixt7x0ULYa3+6HqM7Z1l7PBHF0qjfUlEPZBrW6yUzEuJb4OEQPD5hL2ZmTZua+yEnASKmWE+aorohrnzcTlWYMCr1/6+IOLTLAhZjQLpI4wjcJbJ46hRAfKwMjZshdmIcIILV34zAb/5RgBQSlmJdfjEIv6vsPL4kWHUgqwp+AsgeWKwsMlBKBkp1rYZJr9iGvdJibWsvKLs8jU9oaFVpBg9wGmBk4Ms5ajInP5rKYWQK+fQNfaXyoKDXd30YSoyNaWORfjhiYc8+FHvKLkoYm+8CiTuX8hgC0v4A4IicsihnWB/N35BwVOdZNsHF2WrEpqbRK7sBQ4whdoncFRjNhB7uFYSy2LQtAb+31wb1lUk5nPO6pEweCsp3CrmIHfjDbU87s6p9IGm3QDTp9rhwPibP2RijgJwY9xV+CzAT3fVoIDRPn588ixCXWBHx7UQYqhtdPaBXCSANDJAnH+ndL9M4WlMigna2e16r1KkLkrVlFoCmcdLM2KSDAb9C3OE+EZRURxPGTGzxWFXQ89FHky2hVRuUEYwtWmXzRtoHoxhoNqareW32ezkmJGQZXiVBM2wghFN6iPRxB5KLTBSnX18=
+    - secure: qREG2WSpabHFuvw0IdCNnIwnCRYe9URxIaTOgAw5a5yCItjikSpXYNp5AZAC8TwIA9xh1Xb59r2RU+MLBazo70K5BU8Sdc+k2R1dV9+QxPPuziC/sJch6tgmJl/6BhjnmMKqIsWEsGpXTe1I0/hk2Uu4/JqZlK0KYxrPxzcox90sEDP4lathYPOAXjc5TTELgAIeHxGziI47UPXPjogDRksIc0A9ZBuWb+Ajc470Qn4M9wtg7Tm2xB9H79mlSVzduF5TpPK3q395Krg4/h0gjYgbOk8Nekd9Lqrm0a9dUWC4LwSBUm07obxZr7HabGh7lVqcCsljqUSc+5lBuca+K2os6njvqFPnfyT8E/ZyZDVydT33+wDI0nU5+ZgskMt0NIvRwqWUy7Au96VVCaQa5jVPS14DOIF3vBbT5vnkw50iCeg7HmW/lowoqpJqKlVuJJGufKAIGvcJbeEms8PCxq9j2TjXikmid8fCuOipH9tIckjwS2XtfswPySIJoH1d9Sdtqbm/ABB9cH8No8xx0Gj6uUQKFkl0/7lcWx4vmBIW78GyYKrqVYhyd9W00QFLg9spzBmw3/REch6Kj45YzrAYd6+AQNfIQ/H30Vu43bpUdLnuqt3FVSq+LxyAcKK7R72qy5NgrUz/y0ALU1o+Kbe+WDaRiFGzAvOQBKlO/Gs=
+    - secure: bDH0GRG+D/3vjpgqtTeYjiH0avtSLgvtx9gIFyB9EIwpIjkmz7Bi1vWfzYM1kQmcL8Nd2SpXKPJjniV3/N22Wl6adHigF8v8IbaFwbzhb1pja/5iqqj3UHuYt8dfYWWJYPONzA1SRmn0lQ/mYT0xxtmeNygCP6l7vZ3WQ/Fc15hdGafKtFg9Cqdek27r8oMMgPUrplXEIOxFjm59BcxRR6SCq4Yk6Amdfkktr9wLeO4i5ghFcm/Wt5xlY73kpEiwelQNPaXERedz5x7kDq/sGU+UIKGbDXuSa8ujmzwiK/Igp5ZHT3E1SCExgaHnVMYJY2VMbgHqx79Mew/G8a/c+OnQ9A7AlWWhB9MA0/75qUMeiQENi5rqXU2n2AvB8uBNkQYmxISmUPTYYLGyHXLmWbstnd8KyAE62/hh7WxHMHGD4BNFmPs68QMoeAHwIOoyGX4TfAZvhPV3XjaHlX21pHqEP1PdrCORWXeDA/tFZnnKS8dE2iA6sR2wAY/5yA7nVLKChrvS6ZaOFrRIIyl3KldeJV+0YntK0HRI0da2lnrlv2rVE77ysZ+vf4fRTOfLpQ/ToUqz7HI5UZjKseVLdVjLDTApc2FZJ2443DryqDWD0aNSEgikKulVxc0lGQTxgAHTJ2kZHTzstfn5MnDx1bGMBtVVxykviZvbq8SNOe8=
+    - secure: Mce3HSenklbG1jCxZyuERn/tecMqxhAV42UlQ+6P4gqwxOEVyr4j89AeTrKBnu2Y4nBRd8VdM0y5Y1QH5iK8bZ+IPCWjvWzHz+t+QQ5q5saJfZvRVesgL/P04+CXiK6Z7dEnjmE8zohSGntAIqq02iwgX/DM+Bhk03PXDgoKwQkhOF3gB4BjXaL94shreg1uGNhYpuApZRxBfkZt+rzRdOiCAAlbhsHOxJcluZVAMNo3U9Y1Rbh8dhei8ENqsY+9R7bstRfpKbflMU0W/PxnRjeWWUL8MCTKx4wjoFXd16rsi75hIXe4j/8L0CLraOiGc8DxROK9C3XPFblKIiKaeBj19EhLLJZoTINxoyIYYlrHGdvrmZ8MDPJhUSUH6kid2PoHzod8/9ddM8fbn1xO8+NJ18gqnEZuPDHJa+6oR/y2fb01mZTWyVyc2giNpzCLgCcj1kCLTqXpoEVr6Eb7Bi6lLHUh5f7eeR0HwsCoBVTtyy2SOhgBR2hGuZMGnE18V6s58yDi65RENGr4/YI5D1sYMRRoQgvPv7XG005PyNZHoWsnRopoDSPDHF2bvYvgNrET2HfRihoLZxMmN3L0HNHrYlb4g+qMnwexz7r2uUwflDsV0851mg1BYwBSB6U6eamU28HDunDjvsphpfGtwZZY51E0KTCasBD0X3KkDbo=
+    - CLOUDFRONT_DISTRIBUTION_ID=E3D6RP0POLCJMM
+    - BUCKET_NAME=docs.kuzzle.io
+
 addons:
   apt:
     packages:
-    - jq
-    - python
-    - python-pip
+      - jq
+      - python
+      - python-pip
+
 install:
-- npm install
-- pip install awscli --upgrade --user
-- docker pull alexandrebouthinon/vfinder
+  - npm install
+  - pip install awscli --upgrade --user
+  - docker pull alexandrebouthinon/vfinder
+
 script:
-- npm test
-- if [[ -z $TRAVIS_PULL_REQUEST ]]; then docker run --rm -it -v "$(pwd)":/mnt alexandrebouthinon/vfinder vfinder -d /mnt/build -x /mnt/.vfinder/exceptions -export /mnt/data.json; fi
-- if [[ -z $TRAVIS_PULL_REQUEST ]]; then docker run --rm -it -v "$(pwd)":/mnt alexandrebouthinon/kuttlefish kuttlefish -template /mnt/.vfinder/template.md -data /mnt/data.json -repo documentation -owner kuzzleio -token $GITHUB_TOK -id $TRAVIS_PULL_REQUEST; fi;
+  - npm test
+  - if [[ -z $TRAVIS_PULL_REQUEST ]]; then docker run --rm -it -v "$(pwd)":/mnt alexandrebouthinon/vfinder vfinder -d /mnt/build -x /mnt/.vfinder/exceptions -export /mnt/data.json; fi
+  - if [[ -z $TRAVIS_PULL_REQUEST ]]; then docker run --rm -it -v "$(pwd)":/mnt alexandrebouthinon/kuttlefish kuttlefish -template /mnt/.vfinder/template.md -data /mnt/data.json -repo documentation -owner kuzzleio -token $GITHUB_TOK -id $TRAVIS_PULL_REQUEST; fi;
+
 before_deploy:
-- node index.js --algolia-private-key $ALGOLIA_KEY
+  - node index.js --algolia-private-key $ALGOLIA_KEY
+
 deploy:
+  provider: script
+  script: ~/.local/bin/aws s3 sync build s3://$BUCKET_NAME --delete
+  skip_cleanup: true
   on:
     branch: master
-  provider: s3
-  access_key_id: "$AWS_ACCESS_KEY_ID"
-  secret_access_key: "$AWS_SECRET_ACCESS_KEY"
-  bucket: "$BUCKET_NAME"
-  skip_cleanup: true
-  local_dir: build
-  cache_control: max-age=21600
-  region: us-west-2
+
 after_deploy:
-- aws s3 cp build/index.html s3://$BUCKET_NAME/index.html --website-redirect /guide/getting-started/
-- aws configure set preview.cloudfront true
-- aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID
-  --paths "/*"
+  - aws s3 cp build/index.html s3://$BUCKET_NAME/index.html --website-redirect /guide/getting-started/
+  - aws configure set preview.cloudfront true
+  - aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/*"


### PR DESCRIPTION
## What does this PR do?
Use Travis `script` provider instead of `s3` to allow to `--delete` on deployments

### How should this be manually tested?
You can only check `.travis.yml` syntax