### PR TITLE
Fix layout of the search page

### DIFF
--- a/src/assets/stylesheets/_content.scss
+++ b/src/assets/stylesheets/_content.scss
@@ -12,7 +12,6 @@
 
   h1 {
     font-family: $text-font-family;
-    clear: both;
     @extend %header-font;
     font-size: 4em;
 


### PR DESCRIPTION
## What does this PR do ?
Takes away the `clear: both` rule in the `.content h1` selector in `_content.scss`, which makes the text of some endpoints go below the code snippet.

### How should this be manually tested?
Check the Document Search API page.

fixes #551 